### PR TITLE
Configurable generation of screenshot filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,17 +104,17 @@ You may optionally specify size of browser window in the screenshot step:
 
   Pattern to generate filenames. The following variables are provided:
 
-    | Token | Substituted with | Example value(s) |
-    |--|--|--|
-    | `{ext}` | The extension of the file captured | `html` or `png` |
-    | `{prefix}` | The value of `fail_prefix` above | `failed_`, `error` |
+    | Token            | Substituted with | Example value(s) |
+    |------------------|--|--|
+    | `{ext}`          | The extension of the file captured | `html` or `png` |
+    | `{fail_prefix}`  | The value of `fail_prefix` above | `failed_`, `error` |
     | `{feature_file}` | The filename of the `.feature` file currently being executed | `example.feature` |
-    | `{step_line}` | The line in the `.feature` file currently being executed | `67` |
-    | `{microtime}` | The current microtime to two decimal places | `1697358758.18` |
-    | `{step_text}` | The text of the step currently being executed | `I_am_on_the_test_page` |
-    | `{current_url}` | The URL of the browser | `https_example_org_some_path` |
-    | `{current_path}` | The current path of the browser | `some_path` |
-    | `{current_}*` | Other [parse_url()](https://www.php.net/manual/en/function.parse-url.php) values returned for the current URL. | `https`, `example_org`, `80`, ... |
+    | `{step_line}`    | The line in the `.feature` file currently being executed | `67` |
+    | `{microtime}`    | The current microtime to two decimal places | `1697358758.18` |
+    | `{step_text}`    | The text of the step currently being executed | `I_am_on_the_test_page` |
+    | `{url}`          | The URL of the browser | `https_example_org_some_path` |
+    | `{url:path}`     | The current path of the browser | `some_path` |
+    | `{current_*}`    | Other [parse_url()](https://www.php.net/manual/en/function.parse-url.php) values returned for the current URL. | `https`, `example_org`, `80`, ... |
 
 - `purge:` `true` or `false` (default `false`)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 * Create a screenshot when test fails.
 * Screenshot is saved as HTML page for Goutte driver.
 * Screenshot is saved as both HTML and PNG image for Selenium driver.
-* Screenshot directory can be specified through environment variable `BEHAT_SCREENSHOT_DIR` (useful for CI systems to override values in `behat.yml`).
+* Screenshot directory and filename can be specified through environment variables `BEHAT_SCREENSHOT_DIR` and `BEHAT_SCREENSHOT_FILENAME_PATTERN` (useful for CI systems to override values in `behat.yml`).
 * Screenshots can be purged after every test run by setting `purge: true` (useful during test debugging) or setting environment variable `BEHAT_SCREENSHOT_PURGE=1`.
 
 ## Installation
@@ -67,6 +67,7 @@ default:
       dir: '%paths.base%/screenshots'
       fail: true
       fail_prefix: 'failed_'
+      filename_pattern: '@fail_prefix@feature_file.@step_line.@ext'
       purge: false
 ```
 
@@ -89,6 +90,7 @@ You may optionally specify size of browser window in the screenshot step:
 - `dir:` `path/to/dir` (default `%paths.base%/screenshots`)
 
   Path to directory to save screenshots. Directory structure will be created if the directory does not exist.
+  Can be overridden with `BEHAT_SCREENSHOT_DIR` environment variable.
 
 - `fail:` `true` or `false` (default `true`)
 
@@ -97,6 +99,22 @@ You may optionally specify size of browser window in the screenshot step:
 - `fail_prefix:` (default `failed_`)
 
   Prefix failed screenshots with `fail_` string. Useful to distinguish failed and intended screenshots.
+
+- `filename_pattern:` (default ``)
+
+  Pattern to generate filenames. The following variables are provided:
+
+    | Token | Substituted with | Example value(s) |
+    |--|--|--|
+    | `@ext` | The extension of the file captured | `html` or `png` |
+    | `@prefix` | The value of `fail_prefix` above | `failed_`, `error` |
+    | `@feature_file` | The filename of the `.feature` file currently being executed | `example.feature` |
+    | `@step_line` | The line in the `.feature` file currently being executed | `67` |
+    | `@microtime` | The current microtime to two decimal places | `1697358758.18` |
+    | `@step_text` | The text of the step currently being executed | `I_am_on_the_test_page` |
+    | `@current_url` | The URL of the browser | `https_example_org_some_path` |
+    | `@current_path` | The current path of the browser | `some_path` |
+    | `@current_*` | Other [parse_url()](https://www.php.net/manual/en/function.parse-url.php) values returned for the current URL. | `https`, `example_org`, `80`, ... |
 
 - `purge:` `true` or `false` (default `false`)
 

--- a/README.md
+++ b/README.md
@@ -104,17 +104,18 @@ You may optionally specify size of browser window in the screenshot step:
 
   Pattern to generate filenames. The following variables are provided:
 
-    | Token            | Substituted with | Example value(s) |
-    |------------------|--|--|
-    | `{ext}`          | The extension of the file captured | `html` or `png` |
-    | `{fail_prefix}`  | The value of `fail_prefix` above | `failed_`, `error` |
-    | `{feature_file}` | The filename of the `.feature` file currently being executed | `example.feature` |
-    | `{step_line}`    | The line in the `.feature` file currently being executed | `67` |
-    | `{microtime}`    | The current microtime to two decimal places | `1697358758.18` |
-    | `{step_text}`    | The text of the step currently being executed | `I_am_on_the_test_page` |
-    | `{url}`          | The URL of the browser | `https_example_org_some_path` |
-    | `{url:path}`     | The current path of the browser | `some_path` |
-    | `{current_*}`    | Other [parse_url()](https://www.php.net/manual/en/function.parse-url.php) values returned for the current URL. | `https`, `example_org`, `80`, ... |
+ | Token                           | Substituted with                                                                                               | Example value(s) |
+ |---------------------------------|----------------------------------------------------------------------------------------------------------------|--|
+ | `{datetime}`                    | Current date in `Ymd_His` format                                                                               | `20231128_060912` |
+ | `{datetime:u}`                  | Current date and time as microtime                                                                             | `1701105456.71` |
+ | `{ext}`                         | Extension of the file captured                                                                                 | `html` or `png` |
+ | `{fail_prefix}`                 | Value of `fail_prefix` above                                                                                   | `failed_`, `error` |
+ | `{feature_file}`                | Filename of the `.feature` file currently being executed                                                       | `example.feature` |
+ | `{microtime}`                   | Current microtime to two decimal places                                                                        | `1697358758.18` |
+ | `{step_line}`                   | Line in the `.feature` file currently being executed                                                           | `67` |
+ | `{step_text}`                   | Text of the step currently being executed                                                                      | `I_am_on_the_test_page` |
+ | `{url}`                         | URL of tested browser.                                                                                         | `https_example_org_some_path` |
+ | `{url:host}`, `{url:path}`, ... | URL components of tested browser (ref [`parse_url()`](https://www.php.net/manual/en/function.parse-url.php)).  | `some_path` |
 
 - `purge:` `true` or `false` (default `false`)
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ default:
       dir: '%paths.base%/screenshots'
       fail: true
       fail_prefix: 'failed_'
-      filename_pattern: '@fail_prefix@feature_file.@step_line.@ext'
+      filename_pattern: '{fail_prefix}{feature_file}.{step_line}.{ext}'
       purge: false
 ```
 
@@ -106,15 +106,15 @@ You may optionally specify size of browser window in the screenshot step:
 
     | Token | Substituted with | Example value(s) |
     |--|--|--|
-    | `@ext` | The extension of the file captured | `html` or `png` |
-    | `@prefix` | The value of `fail_prefix` above | `failed_`, `error` |
-    | `@feature_file` | The filename of the `.feature` file currently being executed | `example.feature` |
-    | `@step_line` | The line in the `.feature` file currently being executed | `67` |
-    | `@microtime` | The current microtime to two decimal places | `1697358758.18` |
-    | `@step_text` | The text of the step currently being executed | `I_am_on_the_test_page` |
-    | `@current_url` | The URL of the browser | `https_example_org_some_path` |
-    | `@current_path` | The current path of the browser | `some_path` |
-    | `@current_*` | Other [parse_url()](https://www.php.net/manual/en/function.parse-url.php) values returned for the current URL. | `https`, `example_org`, `80`, ... |
+    | `{ext}` | The extension of the file captured | `html` or `png` |
+    | `{prefix}` | The value of `fail_prefix` above | `failed_`, `error` |
+    | `{feature_file}` | The filename of the `.feature` file currently being executed | `example.feature` |
+    | `{step_line}` | The line in the `.feature` file currently being executed | `67` |
+    | `{microtime}` | The current microtime to two decimal places | `1697358758.18` |
+    | `{step_text}` | The text of the step currently being executed | `I_am_on_the_test_page` |
+    | `{current_url}` | The URL of the browser | `https_example_org_some_path` |
+    | `{current_path}` | The current path of the browser | `some_path` |
+    | `{current_}*` | Other [parse_url()](https://www.php.net/manual/en/function.parse-url.php) values returned for the current URL. | `https`, `example_org`, `80`, ... |
 
 - `purge:` `true` or `false` (default `false`)
 

--- a/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
@@ -30,7 +30,7 @@ class ScreenshotContextInitializer implements ContextInitializer
      *
      * @var string
      */
-    protected $filenamePattern;
+    protected string $filenamePattern;
 
     /**
      * Makes screenshot when fail.

--- a/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
@@ -26,6 +26,13 @@ class ScreenshotContextInitializer implements ContextInitializer
     protected $dir;
 
     /**
+     * Screenshot filename pattern.
+     *
+     * @var string
+     */
+    protected $filenamePattern;
+
+    /**
      * Makes screenshot when fail.
      *
      * @var bool
@@ -56,18 +63,20 @@ class ScreenshotContextInitializer implements ContextInitializer
     /**
      * ScreenshotContextInitializer constructor.
      *
-     * @param string $dir        Screenshot dir.
-     * @param bool   $fail       Screenshot when fail.
-     * @param string $failPrefix File name prefix for a failed test.
-     * @param bool   $purge      Purge dir before start script.
+     * @param string $dir             Screenshot dir.
+     * @param bool   $fail            Screenshot when fail.
+     * @param string $failPrefix      File name prefix for a failed test.
+     * @param bool   $purge           Purge dir before start script.
+     * @param string $filenamePattern Filename pattern to write to.
      */
-    public function __construct(string $dir, bool $fail, string $failPrefix, bool $purge)
+    public function __construct(string $dir, bool $fail, string $failPrefix, bool $purge, string $filenamePattern)
     {
         $this->needsPurging = true;
         $this->dir = $dir;
-        $this->purge = $purge;
         $this->fail = $fail;
         $this->failPrefix = $failPrefix;
+        $this->filenamePattern = $filenamePattern;
+        $this->purge = $purge;
     }
 
     /**
@@ -77,7 +86,8 @@ class ScreenshotContextInitializer implements ContextInitializer
     {
         if ($context instanceof ScreenshotAwareContext) {
             $dir = $this->resolveScreenshotDir();
-            $context->setScreenshotParameters($dir, $this->fail, $this->failPrefix);
+            $filenamePattern = $this->resolveScreenshotFilenamePattern();
+            $context->setScreenshotParameters($dir, $this->fail, $this->failPrefix, $filenamePattern);
             if ($this->shouldPurge() && $this->needsPurging) {
                 $this->purgeFilesInDir($dir);
                 $this->needsPurging = false;
@@ -114,6 +124,22 @@ class ScreenshotContextInitializer implements ContextInitializer
         }
 
         return $this->dir;
+    }
+
+    /**
+     * Resolve filename pattern for screenshots.
+     *
+     * @return string
+     *   Filename pattern containing tokens for replacement.
+     */
+    protected function resolveScreenshotFilenamePattern()
+    {
+        $filenamePattern = getenv('BEHAT_SCREENSHOT_FILENAME_PATTERN');
+        if (!empty($filenamePattern)) {
+            return $filenamePattern;
+        }
+
+        return $this->filenamePattern;
     }
 
     /**

--- a/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
@@ -86,7 +86,7 @@ class ScreenshotContextInitializer implements ContextInitializer
     {
         if ($context instanceof ScreenshotAwareContext) {
             $dir = $this->resolveScreenshotDir();
-            $filenamePattern = $this->resolveScreenshotFilenamePattern();
+            $filenamePattern = $this->resolveScreenshotFilenamePattern($context);
             $context->setScreenshotParameters($dir, $this->fail, $this->failPrefix, $filenamePattern);
             if ($this->shouldPurge() && $this->needsPurging) {
                 $this->purgeFilesInDir($dir);
@@ -132,7 +132,7 @@ class ScreenshotContextInitializer implements ContextInitializer
      * @return string
      *   Filename pattern containing tokens for replacement.
      */
-    protected function resolveScreenshotFilenamePattern()
+    protected function resolveScreenshotFilenamePattern(Context $context)
     {
         $filenamePattern = getenv('BEHAT_SCREENSHOT_FILENAME_PATTERN');
         if (!empty($filenamePattern)) {

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContext.php
@@ -18,12 +18,12 @@ interface ScreenshotAwareContext extends Context
     /**
      * Set context parameters.
      *
-     * @param string      $dir             Directory to store screenshots.
-     * @param bool        $fail            Create screenshots on fail.
-     * @param string      $failPrefix      File name prefix for a failed test.
-     * @param string|null $filenamePattern File name pattern for screenshots.
+     * @param string      $dir              Directory to store screenshots.
+     * @param bool        $fail             Create screenshots on fail.
+     * @param string      $failPrefix       File name prefix for a failed test.
+     * @param string|null $filenameTemplate File name pattern for screenshots.
      *
      * @return $this
      */
-    public function setScreenshotParameters(string $dir, bool $fail, string $failPrefix, string|null $filenamePattern = null): static;
+    public function setScreenshotParameters(string $dir, bool $fail, string $failPrefix, string|null $filenameTemplate = null): static;
 }

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContext.php
@@ -18,11 +18,12 @@ interface ScreenshotAwareContext extends Context
     /**
      * Set context parameters.
      *
-     * @param string $dir        Directory to store screenshots.
-     * @param bool   $fail       Create screenshots on fail.
-     * @param string $failPrefix File name prefix for a failed test.
+     * @param string      $dir             Directory to store screenshots.
+     * @param bool        $fail            Create screenshots on fail.
+     * @param string      $failPrefix      File name prefix for a failed test.
+     * @param string|null $filenamePattern File name pattern for screenshots.
      *
      * @return $this
      */
-    public function setScreenshotParameters(string $dir, bool $fail, string $failPrefix): static;
+    public function setScreenshotParameters(string $dir, bool $fail, string $failPrefix, string|null $filenamePattern = null): static;
 }

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -244,7 +244,7 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
     /**
      * Make screenshot filename.
      *
-     * Format: microseconds.featurefilename_linenumber.ext
+     * Example format: behat-{date:u}.{step_file}-{$step_line}.{ext}
      *
      * @param string $ext    File extension without dot.
      * @param string $prefix Optional file name prefix for a failed test.
@@ -254,16 +254,6 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
     protected function makeFileName(string $ext, string $prefix = ''): string
     {
         $this->setFilenameToken('ext', $ext);
-
-        // Sprintf for step_line.
-        $pattern = '/{(step_line:.*)}/U';
-        preg_match_all($pattern, $this->filenamePattern, $matches);
-        if (!empty($matches[1])) {
-            foreach ($matches as $token) {
-                $parts = explode(':', $token);
-                $this->setFilenameToken("step_line:{$parts[1]}", sprintf($parts[1], $this->stepLine));
-            }
-        }
 
         return strtr($this->filenamePattern, $this->filenameTokens);
     }
@@ -316,6 +306,19 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
             }
         } catch (\Exception $exception) {
             // Browser may not be on a URL yet.
+        }
+
+        // Sprintf for step_line.
+        $pattern = '/{(step_line:.*)}/U';
+        // @FIXME Should use the configured filenamePattern here.
+        preg_match_all($pattern, "some.{step_line:%03d}.other", $matches);
+        if (!empty($matches[1])) {
+            foreach ($matches as $tokens) {
+                foreach ($tokens as $token) {
+                    $parts = explode(':', $token);
+                    $this->setFilenameToken("step_line:{$parts[1]}", sprintf($parts[1], $this->stepLine));
+                }
+            }
         }
     }
 }

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -289,12 +289,12 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
      */
     private function setFilenameTokens(BeforeStepScope $scope) : void
     {
+        $this->setFilenameToken('fail_prefix', $this->failPrefix);
         $this->setFilenameToken('feature_file', basename($this->featureFile));
         $this->setFilenameToken('step_line', (string) $this->stepLine);
         $this->setFilenameToken('step_text', $scope->getStep()->getText());
         $this->setFilenameToken('datetime:u', sprintf('%01.2f', microtime(true)));
         $this->setFilenameToken('datetime', date('Ymd_His'));
-        $this->setFilenameToken('fail_prefix', $this->failPrefix);
         $this->setFilenameToken('url', 'unknown');
         try {
             $currentUrl = $this->getSession()->getDriver()->getCurrentUrl();

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -244,14 +244,14 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
     /**
      * Make screenshot filename.
      *
-     * Example format: behat-{date:u}.{step_file}-{$step_line}.{ext}
+     * Example format: behat-{datetime:u}.{step_file}-{$step_line}.{ext}
      *
      * @param string $ext    File extension without dot.
      * @param string $prefix Optional file name prefix for a failed test.
      *
      * @return string File name.
      */
-    protected function makeFileName(string $ext, string $prefix = ''): string
+    protected function makeFileName(string $ext, string $prefix = '') : string
     {
         $this->setFilenameToken('ext', $ext);
 
@@ -273,7 +273,7 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
     {
         $value = preg_replace("/[^[:alnum:]\.]+/i", "_", (string) $value);
         if (!is_null($value)) {
-            if ('prefix' === $key) {
+            if ('fail_prefix' === $key) {
                 $this->filenameTokens["{{$key}}"] = $value;
             } else {
                 $this->filenameTokens["{{$key}}"] = trim($value, '_');
@@ -287,9 +287,9 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
      * @param BeforeStepScope $scope
      * @return void
      */
-    private function setFilenameTokens(BeforeStepScope $scope)
+    private function setFilenameTokens(BeforeStepScope $scope) : void
     {
-        $this->setFilenameToken('feature_file', basename($this->featureFile));
+        $this->setFilenameToken('feature_file', basename($this->featureFile, '.feature'));
         $this->setFilenameToken('step_line', (string) $this->stepLine);
         $this->setFilenameToken('step_text', $scope->getStep()->getText());
         $this->setFilenameToken('datetime:u', sprintf('%01.2f', microtime(true)));
@@ -311,6 +311,7 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
         // Sprintf for step_line.
         $pattern = '/{(step_line:.*)}/U';
         // @FIXME Should use the configured filenamePattern here.
+        // See journal 2023-11-26.
         preg_match_all($pattern, "some.{step_line:%03d}.other", $matches);
         if (!empty($matches[1])) {
             foreach ($matches as $tokens) {

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -289,7 +289,7 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
      */
     private function setFilenameTokens(BeforeStepScope $scope) : void
     {
-        $this->setFilenameToken('feature_file', basename($this->featureFile, '.feature'));
+        $this->setFilenameToken('feature_file', basename($this->featureFile));
         $this->setFilenameToken('step_line', (string) $this->stepLine);
         $this->setFilenameToken('step_text', $scope->getStep()->getText());
         $this->setFilenameToken('datetime:u', sprintf('%01.2f', microtime(true)));

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -77,7 +77,7 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
      *
      * @var string
      */
-    private $filenamePattern = '@microtime.@prefix@feature_file_@step_line.@ext';
+    private $filenamePattern = '{microtime}.{prefix}{feature_file}_{step_line}.{ext}';
 
     /**
      * Tokens for filename generation.
@@ -277,8 +277,11 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
     /**
      * Set filename tokens, ensuring safe strings.
      *
+     * Retains alphanumeric characters and period, replacing everything else with underscore.
+     * Trims resulting leading/trailing underscores from values except for BC on "prefix".
+     *
      * @param string $key
-     *   Token to set, without @ prefix.
+     *   Token to set, without curly braces.
      * @param string $value
      *   Value to set token to.
      */
@@ -286,7 +289,11 @@ class ScreenshotContext extends RawMinkContext implements SnippetAcceptingContex
     {
         $value = preg_replace("/[^[:alnum:]\.]+/i", "_", $value);
         if (!is_null($value)) {
-            $this->filenameTokens["@{$key}"] = trim($value, '_');
+            if ('prefix' === $key) {
+                $this->filenameTokens["{{$key}}"] = $value;
+            } else {
+                $this->filenameTokens["{{$key}}"] = trim($value, '_');
+            }
         }
     }
 }

--- a/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
+++ b/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
@@ -61,6 +61,7 @@ class BehatScreenshotExtension implements ExtensionInterface
                 ->scalarNode('dir')->cannotBeEmpty()->defaultValue('%paths.base%/screenshots')->end()
                 ->scalarNode('fail')->cannotBeEmpty()->defaultValue(true)->end()
                 ->scalarNode('fail_prefix')->cannotBeEmpty()->defaultValue('failed_')->end()
+                ->scalarNode('filename_pattern')->cannotBeEmpty()->defaultValue('@microtime.@prefix@feature_file_@step_line.@ext')->end()
                 ->scalarNode('purge')->cannotBeEmpty()->defaultValue(false)->end();
         }
     }
@@ -75,6 +76,7 @@ class BehatScreenshotExtension implements ExtensionInterface
             $config['fail'],
             $config['fail_prefix'],
             $config['purge'],
+            $config['filename_pattern'],
         ]);
         $definition->addTag(ContextExtension::INITIALIZER_TAG, ['priority' => 0]);
         $container->setDefinition('drevops_screenshot.screenshot_context_initializer', $definition);

--- a/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
+++ b/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
@@ -61,7 +61,7 @@ class BehatScreenshotExtension implements ExtensionInterface
                 ->scalarNode('dir')->cannotBeEmpty()->defaultValue('%paths.base%/screenshots')->end()
                 ->scalarNode('fail')->cannotBeEmpty()->defaultValue(true)->end()
                 ->scalarNode('fail_prefix')->cannotBeEmpty()->defaultValue('failed_')->end()
-                ->scalarNode('filename_pattern')->cannotBeEmpty()->defaultValue('@microtime.@prefix@feature_file_@step_line.@ext')->end()
+                ->scalarNode('filename_pattern')->cannotBeEmpty()->defaultValue('{microtime}.{prefix}{feature_file}_{step_line}.{ext}')->end()
                 ->scalarNode('purge')->cannotBeEmpty()->defaultValue(false)->end();
         }
     }

--- a/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
+++ b/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
@@ -61,7 +61,7 @@ class BehatScreenshotExtension implements ExtensionInterface
                 ->scalarNode('dir')->cannotBeEmpty()->defaultValue('%paths.base%/screenshots')->end()
                 ->scalarNode('fail')->cannotBeEmpty()->defaultValue(true)->end()
                 ->scalarNode('fail_prefix')->cannotBeEmpty()->defaultValue('failed_')->end()
-                ->scalarNode('filename_pattern')->cannotBeEmpty()->defaultValue('{microtime}.{prefix}{feature_file}_{step_line}.{ext}')->end()
+                ->scalarNode('filename_pattern')->cannotBeEmpty()->defaultValue('{datetime:u}.{fail_prefix}{feature_file}_{step_line}.{ext}')->end()
                 ->scalarNode('purge')->cannotBeEmpty()->defaultValue(false)->end();
         }
     }

--- a/tests/behat/features/behatcli.screenshot.feature
+++ b/tests/behat/features/behatcli.screenshot.feature
@@ -73,6 +73,7 @@ Feature: Screenshot context
     Then it should fail
     And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6\.html" should exist
 
+  @filename_token
   Scenario: Test Screenshot context with env variable BEHAT_SCREENSHOT_FILENAME_PATTERN set to custom value.
     Given screenshot context behat configuration with value:
       """
@@ -90,12 +91,13 @@ Feature: Screenshot context
     Then it should fail
     And behat cli file wildcard "screenshots/screenshot-*.html" should exist
 
+  @filename_token @step_line
   Scenario: Test Screenshot context with configuration 'filename_pattern' set to custom value.
     Given screenshot context behat configuration with value:
       """
       DrevOps\BehatScreenshotExtension:
             fail_prefix: "XFAILX"
-            filename_pattern: "CONFIG.{microtime}.{prefix}.{feature_file}.{step_line}.CONFIG.{ext}"
+            filename_pattern: "CONFIG.{datetime:u}.{fail_prefix}.{feature_file}.{step_line}.CONFIG.{ext}"
       """
     And scenario steps tagged with "@phpserver":
       """
@@ -114,7 +116,7 @@ Feature: Screenshot context
       """
       DrevOps\BehatScreenshotExtension:
             fail_prefix: "XFAILX"
-            filename_pattern: "CONFIG.<token>.CONFIG.{ext}"
+            filename_pattern: "CONFIG.{<token>}.CONFIG.html"
       """
     And scenario steps tagged with "@phpserver":
       """
@@ -128,13 +130,19 @@ Feature: Screenshot context
     Then it should fail
     And behat cli file wildcard "screenshots/CONFIG.<value>.CONFIG.html" should exist
 
-  Examples:
-    | token | value |
-    | {step_line} | 6 |
-    | {feature_file} | stub.feature |
-    | {current_url} | http_phpserver_8888_screenshot.html |
-    | {current_port} | 8888 |
-    | {current_path} | screenshot.html |
+    Examples:
+      | token          | value                                  |
+      | step_line      | 6                                      |
+      | feature_file   | stub.feature                           |
+      | datetime       | 20*_*                                  |
+      | datetime:u     | 1*                                     |
+      | step_text      | the_response_status_code_should_be_404 |
+      | url            | http_phpserver_8888_screenshot.html    |
+      | url:port       | 8888                                   |
+      | url:path       | screenshot.html                        |
+      | url:host       | phpserver                              |
+      | fail_prefix    | XFAILX                                 |
+      # | step_line:%03d | 006                                    |
 
   Scenario: Test Screenshot context with 'fail' set to 'true' which will save screenshot on fail
     Given screenshot context behat configuration with value:
@@ -246,7 +254,7 @@ Feature: Screenshot context
     And behat cli file wildcard "screenshots/*.failed_stub.feature_6\.html" should not exist
 
   Scenario: Test Screenshot context with env variable BEHAT_SCREENSHOT_PURGE set to '1' which will purge files between
-    runs and env variable BEHAT_SCREENSHOT_DIR set to 'screenshots_custom'.
+  runs and env variable BEHAT_SCREENSHOT_DIR set to 'screenshots_custom'.
     Given screenshot context behat configuration with value:
       """
       DrevOps\BehatScreenshotExtension: ~

--- a/tests/behat/features/behatcli.screenshot.feature
+++ b/tests/behat/features/behatcli.screenshot.feature
@@ -21,7 +21,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should pass
-    And behat cli file wildcard "screenshots/stub-7.I_save_screenshot.html" should exist
+    And behat cli file wildcard "screenshots/stub.feature-7.I_save_screenshot.html" should exist
 
   Scenario: Test Screenshot context with no parameters defined in behat.yml
     Given screenshot context behat configuration with value:
@@ -36,7 +36,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should pass
-    And behat cli file wildcard "screenshots/*.stub_7.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_7.html" should exist
 
   Scenario: Test Screenshot context with env variable BEHAT_SCREENSHOT_DIR set to custom dir.
     Given screenshot context behat configuration with value:
@@ -53,7 +53,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots_custom/*.failed_stub_6.html" should exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6.html" should exist
 
   @filename_token
   Scenario: Test Screenshot context with 'dir' set to '%paths.base%/screenshots' and env variable BEHAT_SCREENSHOT_DIR set to custom dir.
@@ -72,7 +72,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots_custom/*.failed_stub_6\.html" should exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub_6.feature.html" should exist
 
   @filename_token
   Scenario: Test Screenshot context with env variable BEHAT_SCREENSHOT_FILENAME_PATTERN set to custom value.
@@ -109,7 +109,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.stub.006.html" should exist
+    And behat cli file wildcard "screenshots/*.stub.feature.006.html" should exist
 
   @filename_token
   Scenario: Test Screenshot context with configuration 'filename_pattern' set to custom value.
@@ -128,7 +128,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/CONFIG.*.XFAILX.stub.6.CONFIG.html" should exist
+    And behat cli file wildcard "screenshots/CONFIG.*.XFAILX.stub.feature.6.CONFIG.html" should exist
 
   @filename_token
   Scenario Outline: Test Screenshot context with configuration 'filename_pattern' set to custom value.
@@ -153,7 +153,7 @@ Feature: Screenshot context
     Examples:
       | token        | value                                  |
       | step_line    | 6                                      |
-      | feature_file | stub                                   |
+      | feature_file | stub.feature                           |
       | datetime     | 20*_*                                  |
       | datetime:u   | 1*                                     |
       | step_text    | the_response_status_code_should_be_404 |
@@ -177,7 +177,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_6.html" should exist
 
   Scenario: Test Screenshot context with 'fail' set to 'false' which will not save screenshot on fail
     Given screenshot context behat configuration with value:
@@ -192,7 +192,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should not exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_6.html" should not exist
 
   Scenario: Test Screenshot context with 'purge' set to 'false' which will not purge files between runs
     Given screenshot context behat configuration with value:
@@ -207,7 +207,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_6.html" should exist
     # Run again, but with error on another line.
     And scenario steps tagged with "@phpserver":
       """
@@ -216,9 +216,9 @@ Feature: Screenshot context
       And the response status code should be 404
       """
     When I run "behat --no-colors --strict"
-    And behat cli file wildcard "screenshots/*.failed_stub_7.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_7.html" should exist
     # Assert that the file from the previous run is still present.
-    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_6.html" should exist
 
   Scenario: Test Screenshot context with 'purge' set to 'true' which will purge files between runs
     Given screenshot context behat configuration with value:
@@ -233,7 +233,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_6.html" should exist
     # Run again, but with error on another line.
     And scenario steps tagged with "@phpserver":
       """
@@ -242,9 +242,9 @@ Feature: Screenshot context
       And the response status code should be 404
       """
     When I run "behat --no-colors --strict"
-    And behat cli file wildcard "screenshots/*.failed_stub_7.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_7.html" should exist
     # Assert that the file from the previous run is not present.
-    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should not exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_6.html" should not exist
 
   Scenario: Test Screenshot context with 'purge' set to 'false', but env variable set to 'true' which will purge files between runs.
     Given screenshot context behat configuration with value:
@@ -259,7 +259,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_6.html" should exist
     # Run again, but with error on another line.
     And scenario steps tagged with "@phpserver":
       """
@@ -269,9 +269,9 @@ Feature: Screenshot context
       """
     When "BEHAT_SCREENSHOT_PURGE" environment variable is set to "1"
     And I run "behat --no-colors --strict"
-    And behat cli file wildcard "screenshots/*.failed_stub_7.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_7.html" should exist
     # Assert that the file from the previous run is not present.
-    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should not exist
+    And behat cli file wildcard "screenshots/*.failed_stub.feature_6.html" should not exist
 
   @testA
   Scenario: Test Screenshot context with env variable BEHAT_SCREENSHOT_PURGE set to '1' which will purge files between
@@ -292,7 +292,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots_custom/*.failed_stub_6.html" should exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6.html" should exist
     # Run again, but with error on another line.
     And scenario steps tagged with "@phpserver":
       """
@@ -301,6 +301,6 @@ Feature: Screenshot context
       And the response status code should be 404
       """
     When I run "behat --no-colors --strict"
-    And behat cli file wildcard "screenshots_custom/*.failed_stub_7.html" should exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_7.html" should exist
     # Assert that the file from the previous run is not present.
-    And behat cli file wildcard "screenshots_custom/*.failed_stub_6.html" should not exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6.html" should not exist

--- a/tests/behat/features/behatcli.screenshot.feature
+++ b/tests/behat/features/behatcli.screenshot.feature
@@ -72,7 +72,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots_custom/*.failed_stub_6.feature.html" should exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6.html" should exist
 
   @filename_token
   Scenario: Test Screenshot context with env variable BEHAT_SCREENSHOT_FILENAME_PATTERN set to custom value.
@@ -152,16 +152,16 @@ Feature: Screenshot context
 
     Examples:
       | token        | value                                  |
-      | step_line    | 6                                      |
-      | feature_file | stub.feature                           |
       | datetime     | 20*_*                                  |
       | datetime:u   | 1*                                     |
+      | fail_prefix  | XFAILX                                 |
+      | feature_file | stub.feature                           |
+      | step_line    | 6                                      |
       | step_text    | the_response_status_code_should_be_404 |
       | url          | http_phpserver_8888_screenshot.html    |
-      | url:port     | 8888                                   |
-      | url:path     | screenshot.html                        |
       | url:host     | phpserver                              |
-      | fail_prefix  | XFAILX                                 |
+      | url:path     | screenshot.html                        |
+      | url:port     | 8888                                   |
       # | step_line:%03d | 006                                    |
 
   Scenario: Test Screenshot context with 'fail' set to 'true' which will save screenshot on fail

--- a/tests/behat/features/behatcli.screenshot.feature
+++ b/tests/behat/features/behatcli.screenshot.feature
@@ -11,7 +11,7 @@ Feature: Screenshot context
             dir: "%paths.base%/screenshots"
             fail: true
             purge: true
-            filename_pattern: "@feature_file-@step_line.@step_text.@ext"
+            filename_pattern: "{feature_file}-{step_line}.{step_text}.{ext}"
       """
     And scenario steps tagged with "@phpserver":
       """
@@ -84,7 +84,7 @@ Feature: Screenshot context
       And the response status code should be 404
       """
     And behat cli file wildcard "screenshots" should not exist
-    And "BEHAT_SCREENSHOT_FILENAME_PATTERN" environment variable is set to "screenshot-@microtime.@ext"
+    And "BEHAT_SCREENSHOT_FILENAME_PATTERN" environment variable is set to "screenshot-{microtime}.{ext}"
 
     When I run "behat --no-colors --strict"
     Then it should fail
@@ -94,8 +94,8 @@ Feature: Screenshot context
     Given screenshot context behat configuration with value:
       """
       DrevOps\BehatScreenshotExtension:
-            fail_prefix: "fail"
-            filename_pattern: "CONFIG.@microtime.@prefix.@feature_file.@step_line.CONFIG.@ext"
+            fail_prefix: "XFAILX"
+            filename_pattern: "CONFIG.{microtime}.{prefix}.{feature_file}.{step_line}.CONFIG.{ext}"
       """
     And scenario steps tagged with "@phpserver":
       """
@@ -106,14 +106,14 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/CONFIG.*.fail.stub.feature.6.CONFIG.html" should exist
+    And behat cli file wildcard "screenshots/CONFIG.*.XFAILX.stub.feature.6.CONFIG.html" should exist
 
   Scenario: Test Screenshot context with configuration 'filename_pattern' set to custom value.
     Given screenshot context behat configuration with value:
       """
       DrevOps\BehatScreenshotExtension:
-            fail_prefix: "fail"
-            filename_pattern: "CONFIG.@microtime.@prefix.@feature_file.@step_line.CONFIG.@ext"
+            fail_prefix: "XFAILX"
+            filename_pattern: "CONFIG.{microtime}.{prefix}.{feature_file}.{step_line}.CONFIG.{ext}"
       """
     And scenario steps tagged with "@phpserver":
       """
@@ -121,11 +121,11 @@ Feature: Screenshot context
       And the response status code should be 404
       """
     And behat cli file wildcard "screenshots" should not exist
-    And "BEHAT_SCREENSHOT_FILENAME_PATTERN" environment variable is set to "ENV.@microtime.@prefix.@feature_file.@step_line.ENV.@ext"
+    And "BEHAT_SCREENSHOT_FILENAME_PATTERN" environment variable is set to "ENV.{microtime}.{prefix}.{feature_file}.{step_line}.ENV.{ext}"
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/ENV.*.fail.stub.feature.6.ENV.html" should exist
+    And behat cli file wildcard "screenshots/ENV.*.XFAILX.stub.feature.6.ENV.html" should exist
 
   Scenario: Test Screenshot context with 'fail' set to 'true' which will save screenshot on fail
     Given screenshot context behat configuration with value:

--- a/tests/behat/features/behatcli.screenshot.feature
+++ b/tests/behat/features/behatcli.screenshot.feature
@@ -108,12 +108,13 @@ Feature: Screenshot context
     Then it should fail
     And behat cli file wildcard "screenshots/CONFIG.*.XFAILX.stub.feature.6.CONFIG.html" should exist
 
-  Scenario: Test Screenshot context with configuration 'filename_pattern' set to custom value.
+  @filename_token
+  Scenario Outline: Test Screenshot context with configuration 'filename_pattern' set to custom value.
     Given screenshot context behat configuration with value:
       """
       DrevOps\BehatScreenshotExtension:
             fail_prefix: "XFAILX"
-            filename_pattern: "CONFIG.{microtime}.{prefix}.{feature_file}.{step_line}.CONFIG.{ext}"
+            filename_pattern: "CONFIG.<token>.CONFIG.{ext}"
       """
     And scenario steps tagged with "@phpserver":
       """
@@ -121,11 +122,19 @@ Feature: Screenshot context
       And the response status code should be 404
       """
     And behat cli file wildcard "screenshots" should not exist
-    And "BEHAT_SCREENSHOT_FILENAME_PATTERN" environment variable is set to "ENV.{microtime}.{prefix}.{feature_file}.{step_line}.ENV.{ext}"
+    # And "BEHAT_SCREENSHOT_FILENAME_PATTERN" environment variable is set to "CONFIG.<token>.{ext}"
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/ENV.*.XFAILX.stub.feature.6.ENV.html" should exist
+    And behat cli file wildcard "screenshots/CONFIG.<value>.CONFIG.html" should exist
+
+  Examples:
+    | token | value |
+    | {step_line} | 6 |
+    | {feature_file} | stub.feature |
+    | {current_url} | http_phpserver_8888_screenshot.html |
+    | {current_port} | 8888 |
+    | {current_path} | screenshot.html |
 
   Scenario: Test Screenshot context with 'fail' set to 'true' which will save screenshot on fail
     Given screenshot context behat configuration with value:

--- a/tests/behat/features/behatcli.screenshot.feature
+++ b/tests/behat/features/behatcli.screenshot.feature
@@ -21,7 +21,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should pass
-    And behat cli file wildcard "screenshots/stub.feature-7.I_save_screenshot.html" should exist
+    And behat cli file wildcard "screenshots/stub-7.I_save_screenshot.html" should exist
 
   Scenario: Test Screenshot context with no parameters defined in behat.yml
     Given screenshot context behat configuration with value:
@@ -36,7 +36,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should pass
-    And behat cli file wildcard "screenshots/*.stub.feature_7\.html" should exist
+    And behat cli file wildcard "screenshots/*.stub_7.html" should exist
 
   Scenario: Test Screenshot context with env variable BEHAT_SCREENSHOT_DIR set to custom dir.
     Given screenshot context behat configuration with value:
@@ -53,7 +53,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6\.html" should exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub_6.html" should exist
 
   @filename_token
   Scenario: Test Screenshot context with 'dir' set to '%paths.base%/screenshots' and env variable BEHAT_SCREENSHOT_DIR set to custom dir.
@@ -72,7 +72,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6\.html" should exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub_6\.html" should exist
 
   @filename_token
   Scenario: Test Screenshot context with env variable BEHAT_SCREENSHOT_FILENAME_PATTERN set to custom value.
@@ -86,7 +86,7 @@ Feature: Screenshot context
       And the response status code should be 404
       """
     And behat cli file wildcard "screenshots" should not exist
-    And "BEHAT_SCREENSHOT_FILENAME_PATTERN" environment variable is set to "screenshot-{microtime}.{ext}"
+    And "BEHAT_SCREENSHOT_FILENAME_PATTERN" environment variable is set to "screenshot-{datetime:u}.{ext}"
 
     When I run "behat --no-colors --strict"
     Then it should fail
@@ -109,7 +109,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.stub.feature.006.html" should exist
+    And behat cli file wildcard "screenshots/*.stub.006.html" should exist
 
   @filename_token
   Scenario: Test Screenshot context with configuration 'filename_pattern' set to custom value.
@@ -128,7 +128,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/CONFIG.*.XFAILX.stub.feature.6.CONFIG.html" should exist
+    And behat cli file wildcard "screenshots/CONFIG.*.XFAILX.stub.6.CONFIG.html" should exist
 
   @filename_token
   Scenario Outline: Test Screenshot context with configuration 'filename_pattern' set to custom value.
@@ -151,17 +151,17 @@ Feature: Screenshot context
     And behat cli file wildcard "screenshots/CONFIG.<value>.CONFIG.html" should exist
 
     Examples:
-      | token          | value                                  |
-      | step_line      | 6                                      |
-      | feature_file   | stub.feature                           |
-      | datetime       | 20*_*                                  |
-      | datetime:u     | 1*                                     |
-      | step_text      | the_response_status_code_should_be_404 |
-      | url            | http_phpserver_8888_screenshot.html    |
-      | url:port       | 8888                                   |
-      | url:path       | screenshot.html                        |
-      | url:host       | phpserver                              |
-      | fail_prefix    | XFAILX                                 |
+      | token        | value                                  |
+      | step_line    | 6                                      |
+      | feature_file | stub                                   |
+      | datetime     | 20*_*                                  |
+      | datetime:u   | 1*                                     |
+      | step_text    | the_response_status_code_should_be_404 |
+      | url          | http_phpserver_8888_screenshot.html    |
+      | url:port     | 8888                                   |
+      | url:path     | screenshot.html                        |
+      | url:host     | phpserver                              |
+      | fail_prefix  | XFAILX                                 |
       # | step_line:%03d | 006                                    |
 
   Scenario: Test Screenshot context with 'fail' set to 'true' which will save screenshot on fail
@@ -177,7 +177,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_6\.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should exist
 
   Scenario: Test Screenshot context with 'fail' set to 'false' which will not save screenshot on fail
     Given screenshot context behat configuration with value:
@@ -192,7 +192,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_6\.html" should not exist
+    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should not exist
 
   Scenario: Test Screenshot context with 'purge' set to 'false' which will not purge files between runs
     Given screenshot context behat configuration with value:
@@ -207,7 +207,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_6\.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should exist
     # Run again, but with error on another line.
     And scenario steps tagged with "@phpserver":
       """
@@ -216,9 +216,9 @@ Feature: Screenshot context
       And the response status code should be 404
       """
     When I run "behat --no-colors --strict"
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_7\.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub_7.html" should exist
     # Assert that the file from the previous run is still present.
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_6\.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should exist
 
   Scenario: Test Screenshot context with 'purge' set to 'true' which will purge files between runs
     Given screenshot context behat configuration with value:
@@ -233,7 +233,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_6\.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should exist
     # Run again, but with error on another line.
     And scenario steps tagged with "@phpserver":
       """
@@ -242,9 +242,9 @@ Feature: Screenshot context
       And the response status code should be 404
       """
     When I run "behat --no-colors --strict"
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_7\.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub_7.html" should exist
     # Assert that the file from the previous run is not present.
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_6\.html" should not exist
+    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should not exist
 
   Scenario: Test Screenshot context with 'purge' set to 'false', but env variable set to 'true' which will purge files between runs.
     Given screenshot context behat configuration with value:
@@ -259,7 +259,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_6\.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should exist
     # Run again, but with error on another line.
     And scenario steps tagged with "@phpserver":
       """
@@ -269,10 +269,11 @@ Feature: Screenshot context
       """
     When "BEHAT_SCREENSHOT_PURGE" environment variable is set to "1"
     And I run "behat --no-colors --strict"
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_7\.html" should exist
+    And behat cli file wildcard "screenshots/*.failed_stub_7.html" should exist
     # Assert that the file from the previous run is not present.
-    And behat cli file wildcard "screenshots/*.failed_stub.feature_6\.html" should not exist
+    And behat cli file wildcard "screenshots/*.failed_stub_6.html" should not exist
 
+  @testA
   Scenario: Test Screenshot context with env variable BEHAT_SCREENSHOT_PURGE set to '1' which will purge files between
   runs and env variable BEHAT_SCREENSHOT_DIR set to 'screenshots_custom'.
     Given screenshot context behat configuration with value:
@@ -291,7 +292,7 @@ Feature: Screenshot context
 
     When I run "behat --no-colors --strict"
     Then it should fail
-    And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6\.html" should exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub_6.html" should exist
     # Run again, but with error on another line.
     And scenario steps tagged with "@phpserver":
       """
@@ -300,6 +301,6 @@ Feature: Screenshot context
       And the response status code should be 404
       """
     When I run "behat --no-colors --strict"
-    And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_7\.html" should exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub_7.html" should exist
     # Assert that the file from the previous run is not present.
-    And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6\.html" should not exist
+    And behat cli file wildcard "screenshots_custom/*.failed_stub_6.html" should not exist

--- a/tests/behat/features/behatcli.screenshot.feature
+++ b/tests/behat/features/behatcli.screenshot.feature
@@ -55,6 +55,7 @@ Feature: Screenshot context
     Then it should fail
     And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6\.html" should exist
 
+  @filename_token
   Scenario: Test Screenshot context with 'dir' set to '%paths.base%/screenshots' and env variable BEHAT_SCREENSHOT_DIR set to custom dir.
     Given screenshot context behat configuration with value:
       """
@@ -91,7 +92,26 @@ Feature: Screenshot context
     Then it should fail
     And behat cli file wildcard "screenshots/screenshot-*.html" should exist
 
-  @filename_token @step_line
+  @filename_token
+  @step_line
+  Scenario: Test Screenshot context with configuration 'filename_pattern' set to custom value.
+    Given screenshot context behat configuration with value:
+      """
+      DrevOps\BehatScreenshotExtension:
+            filename_pattern: "{datetime:u}.{feature_file}.{step_line:%03d}.{ext}"
+      """
+    And scenario steps tagged with "@phpserver":
+      """
+      When I am on the phpserver test page
+      And the response status code should be 404
+      """
+    And behat cli file wildcard "screenshots" should not exist
+
+    When I run "behat --no-colors --strict"
+    Then it should fail
+    And behat cli file wildcard "screenshots/*.stub.feature.006.html" should exist
+
+  @filename_token
   Scenario: Test Screenshot context with configuration 'filename_pattern' set to custom value.
     Given screenshot context behat configuration with value:
       """

--- a/tests/behat/features/behatcli.screenshot.feature
+++ b/tests/behat/features/behatcli.screenshot.feature
@@ -11,6 +11,7 @@ Feature: Screenshot context
             dir: "%paths.base%/screenshots"
             fail: true
             purge: true
+            filename_pattern: "@feature_file-@step_line.@step_text.@ext"
       """
     And scenario steps tagged with "@phpserver":
       """
@@ -20,7 +21,7 @@ Feature: Screenshot context
       """
     When I run "behat --no-colors --strict"
     Then it should pass
-    And behat cli file wildcard "screenshots/*.stub.feature_7\.html" should exist
+    And behat cli file wildcard "screenshots/stub.feature-7.I_save_screenshot.html" should exist
 
   Scenario: Test Screenshot context with no parameters defined in behat.yml
     Given screenshot context behat configuration with value:
@@ -54,7 +55,7 @@ Feature: Screenshot context
     Then it should fail
     And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6\.html" should exist
 
-  Scenario: Test Screenshot context with 'dir' set to '%paths.base%/screenshots' env variable BEHAT_SCREENSHOT_DIR set to custom dir.
+  Scenario: Test Screenshot context with 'dir' set to '%paths.base%/screenshots' and env variable BEHAT_SCREENSHOT_DIR set to custom dir.
     Given screenshot context behat configuration with value:
       """
       DrevOps\BehatScreenshotExtension:
@@ -71,6 +72,60 @@ Feature: Screenshot context
     When I run "behat --no-colors --strict"
     Then it should fail
     And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6\.html" should exist
+
+  Scenario: Test Screenshot context with env variable BEHAT_SCREENSHOT_FILENAME_PATTERN set to custom value.
+    Given screenshot context behat configuration with value:
+      """
+      DrevOps\BehatScreenshotExtension: ~
+      """
+    And scenario steps tagged with "@phpserver":
+      """
+      When I am on the phpserver test page
+      And the response status code should be 404
+      """
+    And behat cli file wildcard "screenshots" should not exist
+    And "BEHAT_SCREENSHOT_FILENAME_PATTERN" environment variable is set to "screenshot-@microtime.@ext"
+
+    When I run "behat --no-colors --strict"
+    Then it should fail
+    And behat cli file wildcard "screenshots/screenshot-*.html" should exist
+
+  Scenario: Test Screenshot context with configuration 'filename_pattern' set to custom value.
+    Given screenshot context behat configuration with value:
+      """
+      DrevOps\BehatScreenshotExtension:
+            fail_prefix: "fail"
+            filename_pattern: "CONFIG.@microtime.@prefix.@feature_file.@step_line.CONFIG.@ext"
+      """
+    And scenario steps tagged with "@phpserver":
+      """
+      When I am on the phpserver test page
+      And the response status code should be 404
+      """
+    And behat cli file wildcard "screenshots" should not exist
+
+    When I run "behat --no-colors --strict"
+    Then it should fail
+    And behat cli file wildcard "screenshots/CONFIG.*.fail.stub.feature.6.CONFIG.html" should exist
+
+  Scenario: Test Screenshot context with configuration 'filename_pattern' set to custom value.
+    Given screenshot context behat configuration with value:
+      """
+      DrevOps\BehatScreenshotExtension:
+            fail_prefix: "fail"
+            filename_pattern: "CONFIG.@microtime.@prefix.@feature_file.@step_line.CONFIG.@ext"
+      """
+    And scenario steps tagged with "@phpserver":
+      """
+      When I am on the phpserver test page
+      And the response status code should be 404
+      """
+    And behat cli file wildcard "screenshots" should not exist
+    And "BEHAT_SCREENSHOT_FILENAME_PATTERN" environment variable is set to "ENV.@microtime.@prefix.@feature_file.@step_line.ENV.@ext"
+
+    When I run "behat --no-colors --strict"
+    Then it should fail
+    And behat cli file wildcard "screenshots/ENV.*.fail.stub.feature.6.ENV.html" should exist
 
   Scenario: Test Screenshot context with 'fail' set to 'true' which will save screenshot on fail
     Given screenshot context behat configuration with value:


### PR DESCRIPTION
This introduces the ability to configure the filenames generated for screenshots more extensively, as proposed in https://github.com/drevops/behat-screenshot/issues/37.

There is a new configuration value `filename_pattern` which can be set in behat.yml or overridden with env var `BEHAT_SCREENSHOT_FILENAME_PATTERN` (as for `BEHAT_SCREENSHOT_DIR`).

This is a text string which permits use of the following tokens:

 | Token                           | Substituted with                                                                                               | Example value(s) |
 |---------------------------------|----------------------------------------------------------------------------------------------------------------|--|
 | `{datetime}`                    | Current date in `Ymd_His` format                                                                               | `20231128_060912` |
 | `{datetime:u}`                  | Current date and time as microtime                                                                             | `1701105456.71` |
 | `{ext}`                         | Extension of the file captured                                                                                 | `html` or `png` |
 | `{fail_prefix}`                 | Value of `fail_prefix` above                                                                                   | `failed_`, `error` |
 | `{feature_file}`                | Filename of the `.feature` file currently being executed                                                       | `example.feature` |
 | `{microtime}`                   | Current microtime to two decimal places                                                                        | `1697358758.18` |
 | `{step_line}`                   | Line in the `.feature` file currently being executed                                                           | `67` |
 | `{step_text}`                   | Text of the step currently being executed                                                                      | `I_am_on_the_test_page` |
 | `{url}`                         | URL of tested browser.                                                                                         | `https_example_org_some_path` |
 | `{url:host}`, `{url:path}`, ... | URL components of tested browser (ref [`parse_url()`](https://www.php.net/manual/en/function.parse-url.php)).  | `some_path` |

If the new configuration values are not set, current filename behaviour will be preserved to avoid impact on any tooling which depends on BC here. Changed defaults could be introduced with an appropriate version increment (not proposed for this MR).

Test coverage and docs in PR hopefully clarify further.

Screenshots from early WIP:

![image](https://github.com/drevops/behat-screenshot/assets/105608/672cacb3-343b-4896-9214-c622b6bbebf4)

![image](https://github.com/drevops/behat-screenshot/assets/105608/9ca43daf-d0cf-464b-ba47-472cc09e84de)

## Tasks

- [x] Docs
- [x] Test coverage
- [x] Implementation
- [x] Maintain existing behaviour by default for BC
- [x] Add `{datetime}` token
- [x] Add `{path}` token
- [x] Add `{ext}` and `{fail_prefix}` tokens
- [x] Add `{feature_file}`, `{step_line}` and `{step_text}` tokens
- [x] Add `{url}` and `{url:*}` (`parse_url()` components) tokens
- [x] Remove comparison with old implementation
- [x] `rebase --autosquash`
- [ ] Optional separate patterns for failed and successful screenshots
- [ ] `{scenario_title}`

## Status

Feedback and input welcome, not ready for review yet - last commit is untested, currently moving tokens from variables on the context into an array to ensure safe values and avoid loading too many new variables onto the class.

Keeping test changes in a separate commit so I can patch the release with composer-patches.
