### PR TITLE
Install Docker Compose for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,14 @@ jobs:
           COMPOSER_ALLOW_SUPERUSER: 1
     steps:
       - checkout
+      - run:
+          name: Install Docker Compose
+          environment:
+            COMPOSE_VERSION: '1.29.2'
+          command: |
+            curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
+            chmod +x ~/docker-compose
+            mv ~/docker-compose /usr/local/bin/docker-compose
       - setup_remote_docker
       - run:
           name: Composer validate.


### PR DESCRIPTION
Per #54 

Compare [this PR's CircleCI run](https://app.circleci.com/pipelines/github/xurizaemon/behat-screenshot/13/workflows/3a5a3502-a19f-4da3-89ee-cdc59164ce75/jobs/14) with that in [an earlier PR from today](https://app.circleci.com/pipelines/github/xurizaemon/behat-screenshot/10/workflows/962c6ade-99ac-48ac-9136-a4942efdd53f/jobs/15), we can see that the earlier run did not progress as far as this one due to the lack of installed Docker Compose.