### PR TITLE
[#133] Added `show_path` configuration to extension to allow adding current URL to screenshot files.

### DIFF
--- a/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
@@ -30,12 +30,14 @@ class ScreenshotContextInitializer implements ContextInitializer {
    *   File name pattern.
    * @param string $filenamePatternFailed
    *   File name pattern failed.
+   * @param bool $showPath
+   *   Show current path in screenshots.
    * @param bool $needsPurging
    *   Check if need to actually purge.
    *
    * @codeCoverageIgnore
    */
-  public function __construct(protected string $dir, protected bool $fail, private readonly string $failPrefix, protected bool $purge, protected string $filenamePattern, protected string $filenamePatternFailed, protected bool $needsPurging = TRUE) {
+  public function __construct(protected string $dir, protected bool $fail, private readonly string $failPrefix, protected bool $purge, protected string $filenamePattern, protected string $filenamePatternFailed, protected bool $showPath = FALSE, protected bool $needsPurging = TRUE) {
   }
 
   /**
@@ -44,7 +46,7 @@ class ScreenshotContextInitializer implements ContextInitializer {
   public function initializeContext(Context $context): void {
     if ($context instanceof ScreenshotAwareContextInterface) {
       $dir = $this->resolveScreenshotDir();
-      $context->setScreenshotParameters($dir, $this->fail, $this->failPrefix, $this->filenamePattern, $this->filenamePatternFailed);
+      $context->setScreenshotParameters($dir, $this->fail, $this->failPrefix, $this->filenamePattern, $this->filenamePatternFailed, $this->showPath);
       if ($this->shouldPurge() && $this->needsPurging) {
         $this->purgeFilesInDir($dir);
         $this->needsPurging = FALSE;

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContextInterface.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContextInterface.php
@@ -24,9 +24,11 @@ interface ScreenshotAwareContextInterface extends Context {
    *   File name pattern.
    * @param string $filenamePatternFailed
    *   File name pattern failed.
+   * @param bool $showPath
+   *   Show path in the screenshot.
    *
    * @return $this
    */
-  public function setScreenshotParameters(string $dir, bool $fail, string $failPrefix, string $filenamePattern, string $filenamePatternFailed): static;
+  public function setScreenshotParameters(string $dir, bool $fail, string $failPrefix, string $filenamePattern, string $filenamePatternFailed, bool $showPath): static;
 
 }

--- a/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
+++ b/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
@@ -76,6 +76,10 @@ class BehatScreenshotExtension implements ExtensionInterface {
       ->scalarNode('filenamePatternFailed')
         ->cannotBeEmpty()
         ->defaultValue('{datetime:U}.{fail_prefix}{feature_file}.feature_{step_line}.{ext}')
+      ->end()
+      ->scalarNode('show_path')
+      ->cannotBeEmpty()
+      ->defaultValue(FALSE)
       ->end();
     // @formatter:on
     // @phpcs:enable Drupal.WhiteSpace.ObjectOperatorIndent.Indent
@@ -92,6 +96,7 @@ class BehatScreenshotExtension implements ExtensionInterface {
       $config['purge'],
       $config['filenamePattern'],
       $config['filenamePatternFailed'],
+      $config['show_path'],
     ]);
     $definition->addTag(ContextExtension::INITIALIZER_TAG, ['priority' => 0]);
     $container->setDefinition('drevops_screenshot.screenshot_context_initializer', $definition);

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -320,6 +320,60 @@ EOL;
   }
 
   /**
+   * Checks whether a screenshot file matching pattern exists and contains text.
+   *
+   * @param string $wildcard
+   *   File name with a wildcard.
+   * @param \Behat\Gherkin\Node\PyStringNode $text
+   *   Text in the file.
+   *
+   * @Given /^behat screenshot file matching "([^"]*)" should contain:$/
+   */
+  public function behatCliAssertFileShouldContain($wildcard, PyStringNode $text): void {
+    $wildcard = $this->workingDir . DIRECTORY_SEPARATOR . $wildcard;
+    $matches = glob($wildcard);
+    if (empty($matches)) {
+      throw new \Exception(sprintf("Unable to find screenshot file matching wildcard '%s'.", $wildcard));
+    }
+    $path = $matches[0];
+    $file_content = trim(file_get_contents($path));
+
+    // Normalize the line endings in the output.
+    if ("\n" !== PHP_EOL) {
+      $file_content = str_replace(PHP_EOL, "\n", $file_content);
+    }
+
+    Assert::assertStringContainsString($this->getExpectedOutput($text), $file_content);
+  }
+
+  /**
+   * Checks whether a screenshot file exists and does not contain given text.
+   *
+   * @param string $wildcard
+   *   File name with a wildcard.
+   * @param \Behat\Gherkin\Node\PyStringNode $text
+   *   Text in the file.
+   *
+   * @Given /^behat screenshot file matching "([^"]*)" should not contain:$/
+   */
+  public function behatCliAssertFileNotShouldContain($wildcard, PyStringNode $text): void {
+    $wildcard = $this->workingDir . DIRECTORY_SEPARATOR . $wildcard;
+    $matches = glob($wildcard);
+    if (empty($matches)) {
+      throw new \Exception(sprintf("Unable to find screenshot file matching wildcard '%s'.", $wildcard));
+    }
+    $path = $matches[0];
+    $file_content = trim(file_get_contents($path));
+
+    // Normalize the line endings in the output.
+    if ("\n" !== PHP_EOL) {
+      $file_content = str_replace(PHP_EOL, "\n", $file_content);
+    }
+
+    Assert::assertStringNotContainsString($this->getExpectedOutput($text), $file_content);
+  }
+
+  /**
    * Checks whether a file wildcard at provided path does not exist.
    *
    * @param string $wildcard

--- a/tests/behat/features/behatcli_screenshot.feature
+++ b/tests/behat/features/behatcli_screenshot.feature
@@ -260,3 +260,41 @@ Feature: Screenshot context
     And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_7\.html" should exist
     # Assert that the file from the previous run is not present.
     And behat cli file wildcard "screenshots_custom/*.failed_stub.feature_6\.html" should not exist
+
+  Scenario: Test Screenshot context with 'show_path' set to 'true' will output current path to screenshot files.
+    Given screenshot context behat configuration with value:
+      """
+      DrevOps\BehatScreenshotExtension:
+            purge: true
+            show_path: true
+      """
+    And scenario steps tagged with "@phpserver":
+      """
+      When I am on the phpserver test page
+      And the response status code should be 404
+      """
+    When I run "behat --no-colors --strict"
+    Then it should fail
+    And behat screenshot file matching "screenshots/*.failed_stub.feature_6\.html" should contain:
+      """
+      Current path: http://0.0.0.0:8888/screenshot.html
+      """
+
+  Scenario: Test Screenshot context with 'show_path' set to 'false' will not output current path to screenshot files.
+    Given screenshot context behat configuration with value:
+      """
+      DrevOps\BehatScreenshotExtension:
+            purge: true
+            show_path: false
+      """
+    And scenario steps tagged with "@phpserver":
+      """
+      When I am on the phpserver test page
+      And the response status code should be 404
+      """
+    When I run "behat --no-colors --strict"
+    Then it should fail
+    And behat screenshot file matching "screenshots/*.failed_stub.feature_6\.html" should not contain:
+      """
+      Current path: http://0.0.0.0:8888/screenshot.html
+      """

--- a/tests/phpunit/Unit/BehatScreenshotExtensionTest.php
+++ b/tests/phpunit/Unit/BehatScreenshotExtensionTest.php
@@ -31,6 +31,7 @@ class BehatScreenshotExtensionTest extends TestCase {
       'purge' => FALSE,
       'filenamePattern' => '{datetime:U}.{feature_file}.feature_{step_line}.{ext}',
       'filenamePatternFailed' => '{datetime:U}.{fail_prefix}{feature_file}.feature_{step_line}.{ext}',
+      'show_path' => FALSE,
     ];
 
     $extension = new BehatScreenshotExtension();
@@ -48,6 +49,7 @@ class BehatScreenshotExtensionTest extends TestCase {
         $config['purge'],
         $config['filenamePattern'],
         $config['filenamePatternFailed'],
+        $config['show_path'],
       ],
       $definition->getArguments()
     );
@@ -59,7 +61,7 @@ class BehatScreenshotExtensionTest extends TestCase {
     $extension = new BehatScreenshotExtension();
     $extension->configure($builder);
 
-    $this->assertCount(6, $builder->getChildNodeDefinitions());
+    $this->assertCount(7, $builder->getChildNodeDefinitions());
   }
 
 }

--- a/tests/phpunit/Unit/ScreenshotContextTest.php
+++ b/tests/phpunit/Unit/ScreenshotContextTest.php
@@ -86,7 +86,8 @@ class ScreenshotContextTest extends TestCase {
       TRUE,
       'failed_',
       '{datetime:U}.{feature_file}.feature_{step_line}.{ext}',
-      '{datetime:U}.{fail_prefix}{feature_file}.feature_{step_line}.{ext}'
+      '{datetime:U}.{fail_prefix}{feature_file}.feature_{step_line}.{ext}',
+      TRUE
     );
     $screenshot_context = $this->createPartialMock(ScreenshotContext::class, ['iSaveScreenshot']);
     $screenshot_context->setScreenshotParameters(
@@ -95,6 +96,7 @@ class ScreenshotContextTest extends TestCase {
       'failed_',
       '{datetime:U}.{feature_file}.feature_{step_line}.{ext}',
       '{datetime:U}.{fail_prefix}{feature_file}.feature_{step_line}.{ext}',
+      TRUE,
     );
     $screenshot_context->expects($this->once())->method('iSaveScreenshot');
     $screenshot_context->printLastResponseOnError($scope);
@@ -161,6 +163,7 @@ class ScreenshotContextTest extends TestCase {
       'failed_',
       '{datetime:U}.{feature_file}.feature_{step_line}.{ext}',
       '{datetime:U}.{fail_prefix}{feature_file}.feature_{step_line}.{ext}',
+      TRUE,
     );
     $screenshot_context_reflection = new \ReflectionClass($screenshot_context);
     $method = $screenshot_context_reflection->getMethod('saveScreenshotData');
@@ -259,6 +262,7 @@ class ScreenshotContextTest extends TestCase {
       $fail_prefix,
       $file_name_pattern,
       $file_name_pattern_failed,
+      TRUE,
     );
 
     $screenshot_context_reflection = new \ReflectionClass($screenshot_context);


### PR DESCRIPTION
Closes: https://github.com/drevops/behat-screenshot/issues/133

## Checklist before requesting a review

- [x] I have formatted the subject to include ticket number as `[#123] Verb in past tense with dot at the end.`
- [x] I have added a link to the issue tracker
- [x] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run new and existing relevant tests locally with my changes, and they passed
- [x] I have provided screenshots, where applicable

## Changed

1. Added configuration flag: `current_path` so that:

```
extensions:
    DrevOps\BehatScreenshotExtension:
      dir: '%paths.base%/.logs/screenshots'
      purge: true
      show_path: true # Change to 'false' to not include the path on html screenshots.
```
will output the current_path to the screenshot html before the opening tag.
3. Updated tests

## Not implemented
1. Watermark of screenshots with current path - deemed too difficult with different sized screens.
2. Hook allowing clients to alter the debug information, I have written the class to allow easier implementation but there does not seem to be an easy way to manage the order of hooks of `@AfterStep` or an easy way to get access to extensions (without DI) etc - if you have ideas let me know,

## Screenshots

![image](https://github.com/user-attachments/assets/26ef2751-c6b7-472d-9bb3-8766110fc313)
