### PR TITLE
Updated default fullscreen algorithm to use `resize`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ default:
       on_failed: true
       purge: false
       always_fullscreen: false
-      fullscreen_algorithm: stitch # Options: 'stitch' or 'resize'
+      fullscreen_algorithm: resize # Options: 'stitch' or 'resize'
       failed_prefix: 'failed_'
       filename_pattern: '{datetime:u}.{feature_file}.feature_{step_line}.{ext}'
       filename_pattern_failed: '{datetime:u}.{failed_prefix}{feature_file}.feature_{step_line}.{ext}'
@@ -90,13 +90,13 @@ Then I save fullscreen screenshot
 
 There are two algorithms available for capturing fullscreen screenshots:
 
-1. **Stitch** (default): Takes multiple screenshots while scrolling the page and
-   stitches them together. This produces high-quality results with proper
-   content rendering but requires the GD extension.
-
-2. **Resize**: Temporarily resizes the browser window to the full height of the
+1. **Resize** (default): Temporarily resizes the browser window to the full height of the
    page to capture everything in one screenshot. This is faster, but may cause
    layout issues on some pages.
+
+2. **Stitch**: Takes multiple screenshots while scrolling the page and
+   stitches them together. This produces high-quality results with proper
+   content rendering but requires the GD extension.
 
 You can configure which algorithm to use via the `fullscreen_algorithm` option:
 
@@ -143,7 +143,7 @@ default:
 | `on_failed`               | `true`                                                                 | Capture screenshot on failed test.                                                                                                                                                                                                                                                              |
 | `purge`                   | `false`                                                                | Remove all files from the screenshots directory on each test run. Useful during debugging of tests.                                                                                                                                                                                             |
 | `always_fullscreen`       | `false`                                                                | Always use fullscreen screenshot capture for all screenshot steps, including regular screenshot steps. When enabled, all `I save screenshot` steps will behave like `I save fullscreen screenshot`.                                                                                             |
-| `fullscreen_algorithm`    | `stitch`                                                               | Algorithm to use for fullscreen screenshots. Options: `stitch` (captures multiple screenshots while scrolling and stitches them together) or `resize` (temporarily resizes browser window to full page height). The stitch algorithm requires GD extension but produces higher quality results. |
+| `fullscreen_algorithm`    | `resize`                                                               | Algorithm to use for fullscreen screenshots. Options: `resize` (temporarily resizes browser window to full page height) or `stitch` (captures multiple screenshots while scrolling and stitches them together). The stitch algorithm requires GD extension but produces higher quality results. |
 | `info_types`              | `url`, `feature`, `step`, `datetime`                                   | Show additional information on screenshots. Comma-separated list of `url`, `feature`, `step`, `datetime`, or remove to disable. Ordered as listed.                                                                                                                                              |
 | `failed_prefix`           | `failed_`                                                              | Prefix failed screenshots with `failed_` string. Useful to distinguish failed and intended screenshots.                                                                                                                                                                                         |
 | `filename_pattern`        | `{datetime:u}.{feature_file}.feature_{step_line}.{ext}`                | File name pattern for successful assertions.                                                                                                                                                                                                                                                    |

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -10,7 +10,7 @@ default:
       on_failed: true
       purge: false
       always_fullscreen: false
-      fullscreen_algorithm: stitch # 'stitch' (only if GD ext available) or 'resize'
+      fullscreen_algorithm: resize # 'stitch' (only if GD ext available) or 'resize'
       info_types:
         - url
         - feature

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -36,7 +36,7 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
   /**
    * Algorithm to use for fullscreen screenshots ('stitch' or 'resize').
    */
-  protected string $fullscreenAlgorithm = 'stitch';
+  protected string $fullscreenAlgorithm = 'resize';
 
   /**
    * Prefix for failed screenshot files.

--- a/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
+++ b/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
@@ -75,7 +75,7 @@ class BehatScreenshotExtension implements ExtensionInterface {
       ->end()
       ->enumNode('fullscreen_algorithm')
         ->values(['stitch', 'resize'])
-        ->defaultValue('stitch')
+        ->defaultValue('resize')
       ->end()
       ->scalarNode('filename_pattern')
         ->cannotBeEmpty()

--- a/tests/phpunit/Unit/BehatScreenshotExtensionTest.php
+++ b/tests/phpunit/Unit/BehatScreenshotExtensionTest.php
@@ -30,7 +30,7 @@ class BehatScreenshotExtensionTest extends TestCase {
       'failed_prefix' => 'failed_',
       'purge' => FALSE,
       'always_fullscreen' => FALSE,
-      'fullscreen_algorithm' => 'stitch',
+      'fullscreen_algorithm' => 'resize',
       'filename_pattern' => '{datetime:U}.{feature_file}.feature_{step_line}.{ext}',
       'filename_pattern_failed' => '{datetime:U}.{failed_prefix}{feature_file}.feature_{step_line}.{ext}',
       'info_types' => FALSE,

--- a/tests/phpunit/Unit/Context/Initializer/ScreenshotContextInitializerTest.php
+++ b/tests/phpunit/Unit/Context/Initializer/ScreenshotContextInitializerTest.php
@@ -30,7 +30,7 @@ class ScreenshotContextInitializerTest extends TestCase {
       'failed_',
       TRUE,
       TRUE,
-      'stitch',
+      'resize',
       '{datetime:U}.{ext}',
       '{datetime:U}.{failed_prefix}{ext}',
       []
@@ -55,7 +55,7 @@ class ScreenshotContextInitializerTest extends TestCase {
         TRUE,
         'failed_',
         TRUE,
-        'stitch',
+        'resize',
         '{datetime:U}.{ext}',
         '{datetime:U}.{failed_prefix}{ext}',
         []
@@ -68,7 +68,7 @@ class ScreenshotContextInitializerTest extends TestCase {
       // don't purge.
       FALSE,
       TRUE,
-      'stitch',
+      'resize',
       '{datetime:U}.{ext}',
       '{datetime:U}.{failed_prefix}{ext}',
       []
@@ -97,7 +97,7 @@ class ScreenshotContextInitializerTest extends TestCase {
           TRUE,
           'failed_',
           TRUE,
-          'stitch',
+          'resize',
           '{datetime:U}.{ext}',
           '{datetime:U}.{failed_prefix}{ext}',
           []
@@ -133,7 +133,7 @@ class ScreenshotContextInitializerTest extends TestCase {
           // Not used due to ENV override.
           FALSE,
           TRUE,
-          'stitch',
+          'resize',
           '{datetime:U}.{ext}',
           '{datetime:U}.{failed_prefix}{ext}',
           [],
@@ -155,7 +155,7 @@ class ScreenshotContextInitializerTest extends TestCase {
           TRUE,
           'failed_',
           TRUE,
-          'stitch',
+          'resize',
           '{datetime:U}.{ext}',
           '{datetime:U}.{failed_prefix}{ext}',
           []


### PR DESCRIPTION
Because of https://github.com/drevops/behat-screenshot/issues/157, we are setting defaults to `resize`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation and example configuration to set "resize" as the default fullscreen screenshot algorithm, with descriptions reordered accordingly.

- **Chores**
  - Changed the default fullscreen screenshot algorithm from "stitch" to "resize" in configuration files and internal settings.

- **Tests**
  - Updated unit tests to reflect "resize" as the default fullscreen screenshot algorithm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->