### PR TITLE
Removed `fullscreen_algorithm` config option in favour of `resize`.

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -39,4 +39,14 @@
     <rule ref="Drupal.Commenting.DocComment.MissingShort">
         <exclude-pattern>tests/behat/bootstrap/BehatCliTrait.php</exclude-pattern>
     </rule>
+
+    <!-- Allow non-Drupal deprecation version format for this non-Drupal package. -->
+    <rule ref="Drupal.Commenting.Deprecated.DeprecatedVersionFormat">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Allow non-Drupal.org @see URLs in deprecation tags. -->
+    <rule ref="Drupal.Commenting.Deprecated.DeprecatedWrongSeeUrlFormat">
+        <severity>0</severity>
+    </rule>
 </ruleset>

--- a/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
@@ -36,7 +36,9 @@ class ScreenshotContextInitializer implements ContextInitializer {
    * @param bool $onEveryStep
    *   Capture screenshot after every step.
    * @param string $fullscreenAlgorithm
-   *   Algorithm to use for fullscreen screenshots ('stitch' or 'resize').
+   *   Algorithm to use for fullscreen screenshots. This parameter is
+   *   deprecated and will be ignored. The algorithm is now always set to
+   *   'resize'.
    * @param string $filenamePattern
    *   File name pattern.
    * @param string $filenamePatternFailed

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContextInterface.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContextInterface.php
@@ -25,7 +25,9 @@ interface ScreenshotAwareContextInterface extends Context {
    * @param bool $on_every_step
    *   Capture screenshot after every step.
    * @param string $fullscreen_algorithm
-   *   Algorithm to use for fullscreen screenshots ('stitch' or 'resize').
+   *   Algorithm to use for fullscreen screenshots. This parameter is
+   *   deprecated and will be ignored. The algorithm is now always set to
+   *   'resize'.
    * @param string $filename_pattern
    *   File name pattern.
    * @param string $filename_pattern_failed

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -44,7 +44,11 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
   protected bool $scenarioHasScreenshotsTag = FALSE;
 
   /**
-   * Algorithm to use for fullscreen screenshots ('stitch' or 'resize').
+   * Algorithm to use for fullscreen screenshots.
+   *
+   * @deprecated in behat-screenshot:2.2 and is removed from
+   *   behat-screenshot:2.3. The algorithm is now always set to 'resize'.
+   * @see \DrevOps\BehatScreenshotExtension\Context\ScreenshotContext::getScreenshotFullscreenWithResize()
    */
   protected string $fullscreenAlgorithm = 'resize';
 
@@ -322,14 +326,12 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
 
   /**
    * Get fullscreen screenshot.
+   *
+   * Note: The algorithm is now always set to 'resize'. The 'stitch' algorithm
+   * is deprecated and will be removed in a future version.
    */
   public function getScreenshotFullscreen(): string {
-    // Use the configured algorithm if both are available.
-    if ($this->fullscreenAlgorithm === 'stitch' && extension_loaded('gd') && function_exists('imagecreatetruecolor')) {
-      return $this->getScreenshotFullscreenWithStitching();
-    }
-
-    // Fall back to resize if stitching is unavailable or resize was selected.
+    // Always use the resize algorithm.
     return $this->getScreenshotFullscreenWithResize();
   }
 
@@ -338,6 +340,10 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
    *
    * @return string
    *   Screenshot data.
+   *
+   * @deprecated in behat-screenshot:2.2 and is removed from
+   *   behat-screenshot:2.3. Use getScreenshotFullscreenWithResize() instead.
+   * @see \DrevOps\BehatScreenshotExtension\Context\ScreenshotContext::getScreenshotFullscreenWithResize()
    */
   protected function getScreenshotFullscreenWithStitching(): string {
     $session = $this->getSession();
@@ -573,6 +579,10 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
    *
    * @return string
    *   The stitched image as a binary string.
+   *
+   * @deprecated in behat-screenshot:2.2 and is removed from
+   *   behat-screenshot:2.3. Use getScreenshotFullscreenWithResize() instead.
+   * @see \DrevOps\BehatScreenshotExtension\Context\ScreenshotContext::getScreenshotFullscreenWithResize()
    */
   protected function stitchImages(array $images, int $width, int $viewport_height, int $overlap): string {
     if (empty($images)) {

--- a/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
+++ b/src/DrevOps/BehatScreenshotExtension/ServiceContainer/BehatScreenshotExtension.php
@@ -80,6 +80,7 @@ class BehatScreenshotExtension implements ExtensionInterface {
       ->enumNode('fullscreen_algorithm')
         ->values(['stitch', 'resize'])
         ->defaultValue('resize')
+        ->setDeprecated('drevops/behat-screenshot', '2.2', 'The "%node%" option is deprecated. The fullscreen screenshot algorithm is now always set to "resize".')
       ->end()
       ->scalarNode('filename_pattern')
         ->cannotBeEmpty()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Fullscreen screenshots now always use the resize algorithm; stitching is ignored.
  - The configuration option for selecting the fullscreen algorithm is deprecated.

- Documentation
  - Updated docs to mark stitching-related paths and fullscreen algorithm parameters as deprecated and ignored.

- Style
  - Adjusted coding standards to allow non-Drupal deprecation version formats and non-drupal.org @see URLs in deprecation tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->