### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,20 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "dependencyDashboard": true,
+    "extends": ["config:recommended"],
     "automerge": true,
-    "extends": [
-        "config:base"
+    "rangeStrategy": "bump",
+    "dependencyDashboard": true,
+    "pinDigests": true,
+    "branchPrefix": "deps/",
+    "packageRules": [
+        {
+            "matchManagers": ["composer"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "matchPackageNames": ["*"],
+            "groupName": "all dependencies",
+            "groupSlug": "all"
+        }
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,17 @@
     "branchPrefix": "deps/",
     "packageRules": [
         {
+            "matchDepNames": ["php"],
             "matchManagers": ["composer"],
+            "enabled": false
+        },
+        {
+            "matchDepNames": ["node", "yarn"],
+            "matchManagers": ["npm"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["npm", "composer"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },

--- a/src/DrevOps/BehatScreenshotExtension/Tokenizer.php
+++ b/src/DrevOps/BehatScreenshotExtension/Tokenizer.php
@@ -194,29 +194,29 @@ class Tokenizer {
 
       switch ($qualifier) {
         case 'origin':
-          $replacement = sprintf('%s://%s', $url_parts['scheme'], $url_parts['host']);
+          $replacement = sprintf('%s://%s', $url_parts['scheme'] ?? '', $url_parts['host'] ?? '');
           break;
 
         case 'relative':
-          $replacement = trim($url_parts['path'], '/');
+          $replacement = trim($url_parts['path'] ?? '', '/');
           $replacement = isset($url_parts['query']) ? $replacement . '?' . $url_parts['query'] : $replacement;
           $replacement = isset($url_parts['fragment']) ? $replacement . '#' . $url_parts['fragment'] : $replacement;
           break;
 
         case 'domain':
-          $replacement = $url_parts['host'];
+          $replacement = $url_parts['host'] ?? '';
           break;
 
         case 'path':
-          $replacement = trim($url_parts['path'], '/');
+          $replacement = trim($url_parts['path'] ?? '', '/');
           break;
 
         case 'query':
-          $replacement = $url_parts['query'] ?: '';
+          $replacement = $url_parts['query'] ?? '';
           break;
 
         case 'fragment':
-          $replacement = $url_parts['fragment'] ?: '';
+          $replacement = $url_parts['fragment'] ?? '';
           break;
 
         default:

--- a/tests/phpunit/Unit/ScreenshotContextTest.php
+++ b/tests/phpunit/Unit/ScreenshotContextTest.php
@@ -32,7 +32,7 @@ class ScreenshotContextTest extends TestCase {
     $feature_node = $this->createMock(FeatureNode::class);
     $scenario = $this->createMock(ScenarioInterface::class);
     $scenario
-      ->method('hasTag')->with('javascript')->willReturn(TRUE);
+      ->expects($this->any())->method('hasTag')->with('javascript')->willReturn(TRUE);
     $session = $this->createMock(Session::class);
     $driver = $this->createMock(Selenium2Driver::class);
     $driver->method('start')->willThrowException(new \RuntimeException('Test Exception.'));


### PR DESCRIPTION
Updated renovate.json with standardised config via repoRanger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched dependency management to the recommended configuration: enabled dependency dashboard, digest pinning, branch prefix, standardized bump strategy, grouped all deps, and disabled specific ecosystem/version update types.

* **Bug Fixes**
  * Made URL token handling defensive so missing URL parts yield empty values instead of undefined behavior.

* **Tests**
  * Relaxed a unit-test expectation to allow repeated tag checks while still returning true.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->