### PR TITLE
Fixed animated GIF frames being stretched to the first frame's dimensions.

### DIFF
--- a/src/DrevOps/BehatScreenshotExtension/AnimatedGif.php
+++ b/src/DrevOps/BehatScreenshotExtension/AnimatedGif.php
@@ -34,7 +34,7 @@ class AnimatedGif {
    *
    * @param array<int,string> $frames
    *   Raw image data for each frame, in any format readable by GD (e.g. PNG).
-   *   Frames are normalised to the dimensions of the first decodable frame.
+   *   Frames are padded to the largest frame's dimensions, never stretched.
    * @param int $frame_delay
    *   Delay between frames, in milliseconds.
    *
@@ -63,25 +63,35 @@ class AnimatedGif {
    *   Raw image data for each frame.
    *
    * @return array<int,string>
-   *   Single-frame GIF binaries, all sharing the first frame's dimensions.
+   *   Single-frame GIF binaries, all sharing the largest frame's dimensions.
    */
   protected function normaliseFrames(array $frames): array {
-    $gif_frames = [];
-    $width = NULL;
-    $height = NULL;
+    // Size the canvas to the largest frame so each frame keeps its own aspect
+    // ratio. Resampling frames of different sizes to a single size distorts
+    // them - smaller frames are padded instead, and nothing is stretched.
+    $width = 0;
+    $height = 0;
+    foreach ($frames as $frame) {
+      $size = @getimagesizefromstring($frame);
+      if ($size !== FALSE) {
+        $width = max($width, $size[0]);
+        $height = max($height, $size[1]);
+      }
+    }
 
+    if ($width < 1 || $height < 1) {
+      throw new \InvalidArgumentException('None of the provided frames could be decoded as an image.');
+    }
+
+    $gif_frames = [];
     foreach ($frames as $frame) {
       $image = @imagecreatefromstring($frame);
       if (!$image instanceof \GdImage) {
         continue;
       }
 
-      if ($width === NULL || $height === NULL) {
-        $width = imagesx($image);
-        $height = imagesy($image);
-      }
-      elseif (imagesx($image) !== $width || imagesy($image) !== $height) {
-        $image = $this->resize($image, max(1, $width), max(1, $height));
+      if (imagesx($image) !== $width || imagesy($image) !== $height) {
+        $image = $this->pad($image, $width, $height);
       }
 
       ob_start();
@@ -94,37 +104,42 @@ class AnimatedGif {
       }
     }
 
+    // @codeCoverageIgnoreStart
     if ($gif_frames === []) {
       throw new \InvalidArgumentException('None of the provided frames could be decoded as an image.');
     }
 
+    // @codeCoverageIgnoreEnd
     return $gif_frames;
   }
 
   /**
-   * Resize an image onto a new canvas of the given dimensions.
+   * Pad an image onto a larger canvas without scaling it.
    *
    * @param \GdImage $image
-   *   Source image. Destroyed once copied onto the new canvas.
+   *   Source image. Destroyed once copied onto the canvas.
    * @param positive-int $width
-   *   Target width.
+   *   Canvas width.
    * @param positive-int $height
-   *   Target height.
+   *   Canvas height.
    *
    * @return \GdImage
-   *   Resized image on a new canvas.
+   *   The source image placed top-left on a white canvas of the given size.
    */
-  protected function resize(\GdImage $image, int $width, int $height): \GdImage {
+  protected function pad(\GdImage $image, int $width, int $height): \GdImage {
     $canvas = imagecreatetruecolor($width, $height);
 
     // @codeCoverageIgnoreStart
     if (!$canvas instanceof \GdImage) {
       imagedestroy($image);
 
-      throw new \RuntimeException('Unable to create a canvas for resizing an animation frame.');
+      throw new \RuntimeException('Unable to create a canvas for an animation frame.');
     }
     // @codeCoverageIgnoreEnd
-    imagecopyresampled($canvas, $image, 0, 0, 0, 0, $width, $height, imagesx($image), imagesy($image));
+    // Smaller frames sit on a white background rather than being stretched.
+    $background = (int) imagecolorallocate($canvas, 255, 255, 255);
+    imagefilledrectangle($canvas, 0, 0, $width - 1, $height - 1, $background);
+    imagecopy($canvas, $image, 0, 0, 0, 0, imagesx($image), imagesy($image));
     imagedestroy($image);
 
     return $canvas;

--- a/tests/phpunit/Unit/AnimatedGifTest.php
+++ b/tests/phpunit/Unit/AnimatedGifTest.php
@@ -34,7 +34,7 @@ class AnimatedGifTest extends TestCase {
     $this->assertSame([120, 90], $this->imageSize($gif));
   }
 
-  public function testEncodeNormalisesDifferentlySizedFrames(): void {
+  public function testEncodePadsFramesToLargestFrame(): void {
     $frames = [
       $this->createPngFrame(100, 100, [10, 20, 30]),
       $this->createPngFrame(64, 48, [200, 100, 50]),
@@ -46,8 +46,26 @@ class AnimatedGifTest extends TestCase {
     $this->assertStringStartsWith('GIF89a', $gif);
     $this->assertEquals(3, substr_count($gif, "\x21\xF9\x04"));
 
-    // All frames are normalised to the first frame's dimensions.
-    $this->assertSame([100, 100], $this->imageSize($gif));
+    // The canvas matches the largest frame; smaller frames are padded,
+    // not scaled.
+    $this->assertSame([150, 120], $this->imageSize($gif));
+  }
+
+  public function testEncodeDoesNotStretchSmallerFrames(): void {
+    // A small red frame followed by a larger blue frame.
+    $frames = [
+      $this->createPngFrame(40, 30, [255, 0, 0]),
+      $this->createPngFrame(80, 60, [0, 0, 255]),
+    ];
+
+    $gif = (new AnimatedGif())->encode($frames, 100);
+
+    // The canvas is the larger frame's size.
+    $this->assertSame([80, 60], $this->imageSize($gif));
+    // The small frame keeps its native size at the top-left: its own area is
+    // red and the rest is white padding - it is not stretched to fill.
+    $this->assertColorNear([255, 0, 0], $this->pixelColor($gif, 5, 5));
+    $this->assertColorNear([255, 255, 255], $this->pixelColor($gif, 70, 50));
   }
 
   public function testEncodeHandlesFramesWithExtensionBlocks(): void {
@@ -83,6 +101,20 @@ class AnimatedGifTest extends TestCase {
     // byte for byte.
     $this->assertEquals($this->gifSignature($expected), $this->gifSignature($produced));
     $this->assertSame([80, 60], $this->imageSize($produced));
+  }
+
+  public function testEncodeSkipsUndecodableFrames(): void {
+    $frames = [
+      $this->createPngFrame(30, 20, [0, 128, 0]),
+      'not-an-image',
+    ];
+
+    $gif = (new AnimatedGif())->encode($frames, 100);
+
+    $this->assertStringStartsWith('GIF89a', $gif);
+    // Only the single decodable frame ends up in the animation.
+    $this->assertEquals(1, substr_count($gif, "\x21\xF9\x04"));
+    $this->assertSame([30, 20], $this->imageSize($gif));
   }
 
   public function testEncodeThrowsWhenNoFramesProvided(): void {
@@ -235,6 +267,45 @@ class AnimatedGifTest extends TestCase {
     imagedestroy($image);
 
     return $size;
+  }
+
+  /**
+   * Read the RGB colour of a pixel in the first frame of an image.
+   *
+   * @param string $data
+   *   Binary image data.
+   * @param int $x
+   *   Pixel x coordinate.
+   * @param int $y
+   *   Pixel y coordinate.
+   *
+   * @return array<int,int>
+   *   The red, green and blue components, or [-1, -1, -1] when undecodable.
+   */
+  protected function pixelColor(string $data, int $x, int $y): array {
+    $image = imagecreatefromstring($data);
+    if (!$image instanceof \GdImage) {
+      return [-1, -1, -1];
+    }
+
+    $colors = imagecolorsforindex($image, (int) imagecolorat($image, $x, $y));
+    imagedestroy($image);
+
+    return [$colors['red'], $colors['green'], $colors['blue']];
+  }
+
+  /**
+   * Assert two colours match within a tolerance to allow for GIF quantisation.
+   *
+   * @param array<int,int> $expected
+   *   Expected red, green and blue components.
+   * @param array<int,int> $actual
+   *   Actual red, green and blue components.
+   */
+  protected function assertColorNear(array $expected, array $actual): void {
+    foreach ($expected as $channel => $value) {
+      $this->assertEqualsWithDelta($value, $actual[$channel], 24);
+    }
   }
 
 }


### PR DESCRIPTION
## Summary

This is a follow-up bugfix to the animated GIF recording feature (#40, PR #226). The `AnimatedGif` encoder previously resampled every frame to the dimensions of the *first* decodable frame, which distorted frames of a different size - a short blank first frame would make the canvas short, so taller full-page frames were vertically squashed. The fix sizes the GIF canvas to the *largest* frame and places smaller frames at their native size (top-left, white background), so nothing is ever stretched or distorted.

## Changes

**`src/DrevOps/BehatScreenshotExtension/AnimatedGif.php`**
- Added a first pass over `$frames` to find the maximum width and height before encoding, so the canvas is sized to the largest frame rather than the first.
- Replaced the `resize()` method (which used `imagecopyresampled` and stretched the image) with a `pad()` method that copies the source image at its native size onto a white canvas of the target dimensions.
- Updated docblocks and inline comments to reflect the new pad-to-largest contract.
- Guarded the now-unreachable "no frames decoded" branch inside the loop with `@codeCoverageIgnore` (the identical guard at the top of the method catches it first).

**`tests/phpunit/Unit/AnimatedGifTest.php`**
- Renamed `testEncodeNormalisesDifferentlySizedFrames` to `testEncodePadsFramesToLargestFrame` and updated its assertion: the canvas must equal the *largest* frame's size, not the first frame's size.
- Added `testEncodeDoesNotStretchSmallerFrames`: creates a small red frame and a larger blue frame, then checks pixel-level that the small frame occupies only its own corner (red) and the remainder is white padding, not a stretched version of the red frame.
- Added `testEncodeSkipsUndecodableFrames`: verifies that frames with invalid image data are silently skipped while valid frames are still encoded.
- Added `pixelColor()` helper to read an RGB pixel from binary image data.
- Added `assertColorNear()` helper to compare colours within a tolerance of ±24 per channel, accommodating GIF's 256-colour quantisation.

## Before / After

```
Before (resize / distort)
  Frame 1: 100×20  (short blank)      ─┐
  Frame 2: 100×800 (full page)         │ all resampled to 100×20
  Frame 3: 100×600 (full page)        ─┘  → frames 2 & 3 squashed vertically

After (pad to largest)
  Canvas:  100×800 (largest frame)    ─┐
  Frame 1: 100×20  placed top-left    │ white padding fills the rest
  Frame 2: 100×800 placed top-left    │ no scaling applied
  Frame 3: 100×600 placed top-left   ─┘  → all frames at native aspect ratio
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Animated GIF encoding now pads frames to the largest frame dimensions instead of resizing all frames, preserving original frame proportions.
  * Undecodable frames are now properly skipped during GIF encoding, improving robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->