### PR TITLE
Fixed coding standards violations reported by 'composer lint'.

### DIFF
--- a/src/DrevOps/BehatScreenshotExtension/AnimatedGif.php
+++ b/src/DrevOps/BehatScreenshotExtension/AnimatedGif.php
@@ -99,7 +99,7 @@ class AnimatedGif {
       $gif = ob_get_clean();
       imagedestroy($image);
 
-      if (is_string($gif) && $gif !== '') {
+      if ($gif !== '') {
         $gif_frames[] = $gif;
       }
     }

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContextInterface.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContextInterface.php
@@ -32,8 +32,6 @@ interface ScreenshotAwareContextInterface extends Context {
    *   Show these info types in the screenshot.
    * @param array<string,mixed> $animation
    *   Animated GIF settings (keys: enabled, frame_delay).
-   *
-   * @return $this
    */
   public function setScreenshotParameters(string $dir, bool $on_failed, string $failed_prefix, bool $always_fullscreen, bool $on_every_step, string $filename_pattern, string $filename_pattern_failed, array $info_types, array $animation): static;
 

--- a/tests/phpunit/Unit/AnimatedGifTest.php
+++ b/tests/phpunit/Unit/AnimatedGifTest.php
@@ -180,7 +180,7 @@ class AnimatedGifTest extends TestCase {
     $data = ob_get_clean();
     imagedestroy($image);
 
-    return is_string($data) ? $data : '';
+    return $data;
   }
 
   /**
@@ -210,7 +210,7 @@ class AnimatedGifTest extends TestCase {
     $data = ob_get_clean();
     imagedestroy($image);
 
-    return is_string($data) ? $data : '';
+    return $data;
   }
 
   /**


### PR DESCRIPTION
## Summary

Removes coding-standards and static-analysis violations surfaced by `composer lint`. PHPStan flagged two `is_string()` checks as redundant because the values they guarded are already known to be strings at that point, and Rector flagged a duplicate `@return $this` docblock tag on a method that already declares a native `static` return type.

## Changes

- `src/DrevOps/BehatScreenshotExtension/AnimatedGif.php`: simplified the frame-collection guard in `toGif()` from `is_string($gif) && $gif !== ''` to `$gif !== ''`, since `is_string($gif)` was always true.
- `tests/phpunit/Unit/AnimatedGifTest.php`: simplified `createPngFrame()` and `createTransparentPngFrame()` to `return $data;` instead of `return is_string($data) ? $data : '';`, for the same reason.
- `src/DrevOps/BehatScreenshotExtension/Context/ScreenshotAwareContextInterface.php`: removed the duplicate `@return $this` docblock tag from `setScreenshotParameters()`, which already declares `: static` as its native return type.

## Before / After

```
Before                                              After
------------------------------------------------    ------------------------------------------------
if (is_string($gif) && $gif !== '') {         -->    if ($gif !== '') {
  $gif_frames[] = $gif;                                $gif_frames[] = $gif;
}                                                     }

return is_string($data) ? $data : '';         -->    return $data;

/**                                            -->    /**
 * ...                                                 * ...
 *                                                     */
 * @return $this
 */
```
