### PR TITLE
[#241] Added a profiler that measures animated GIF assembly cost and memory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,20 @@ composer test-unit
 composer test-bdd
 ```
 
+### Profiling animated GIF assembly
+
+Building a scenario's animated GIF happens in the `AfterScenario` handler, so its cost lands as a pause after the scenario's last step rather than as slower steps. The profiler replays a scenario of a given length through the real hooks and reports how long each phase took, how much memory peaked, and how many pixels were encoded compared to how many were captured.
+
+It is excluded from `composer test` because it takes minutes to run.
+
+```shell
+composer profile  # Profile 25, 50 and 100-step scenarios.
+
+BEHAT_SCREENSHOT_PROFILE_STEPS=10,20 composer profile  # Profile other lengths.
+```
+
+The report is printed and written to `.logs/profile/animation-assembly.txt`, which CI collects as a build artifact.
+
 ### BDD tests
 
 There are tests for Selenium and Headless drivers. Selenium requires a Docker

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
             "rector",
             "phpcbf"
         ],
+        "profile": "phpunit --group profile --no-coverage --do-not-cache-result",
         "reset": "rm -Rf vendor vendor-bin composer.lock",
         "test": "phpunit --no-coverage",
         "test-bdd": "behat --colors",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,12 @@
             <directory>tests/phpunit</directory>
         </testsuite>
     </testsuites>
+    <groups>
+        <exclude>
+            <!-- Profiling takes minutes; run it with `composer profile`. -->
+            <group>profile</group>
+        </exclude>
+    </groups>
     <source restrictNotices="true"
             restrictWarnings="true"
             ignoreIndirectDeprecations="true">

--- a/tests/phpunit/Profile/AnimationAssemblyProfileTest.php
+++ b/tests/phpunit/Profile/AnimationAssemblyProfileTest.php
@@ -55,6 +55,16 @@ class AnimationAssemblyProfileTest extends TestCase {
    */
   protected const DEFAULT_STEPS = [25, 50, 100];
 
+  protected function setUp(): void {
+    parent::setUp();
+
+    // GD is a suggested dependency, so the profiler has nothing to measure
+    // without it - the animation is skipped at runtime for the same reason.
+    if (!function_exists('imagecreatetruecolor') || !function_exists('imagegif')) {
+      $this->markTestSkipped('Profiling animated GIF assembly requires the gd extension.');
+    }
+  }
+
   public function testAnimationAssemblyCost(): void {
     $steps = $this->stepCounts();
 
@@ -96,11 +106,12 @@ class AnimationAssemblyProfileTest extends TestCase {
 
     $this->writeReport(implode("\n", $report) . "\n");
 
-    // The measurement is only meaningful if the work really does happen at
-    // scenario end rather than during the steps.
+    // The timings only describe something real if each scenario did produce an
+    // animation. Comparing the two timings against each other would be a race
+    // rather than an assertion, so the report is left to show that.
     foreach ($rows as $by_step) {
       foreach ($by_step as $row) {
-        $this->assertGreaterThan($row['steps'], $row['assembly']);
+        $this->assertGreaterThan(0, $row['bytes']);
       }
     }
   }
@@ -319,7 +330,11 @@ class AnimationAssemblyProfileTest extends TestCase {
       throw new \RuntimeException(sprintf('Unable to create the profile directory %s.', $dir));
     }
 
-    file_put_contents($dir . '/animation-assembly.txt', $report);
+    $file = $dir . '/animation-assembly.txt';
+    if (file_put_contents($file, $report) === FALSE) {
+      throw new \RuntimeException(sprintf('Unable to write the profile report to %s.', $file));
+    }
+
     // Diagnostics go to STDERR so the strict no-output-during-tests rule that
     // guards the default suite still holds.
     fwrite(STDERR, $report);

--- a/tests/phpunit/Profile/AnimationAssemblyProfileTest.php
+++ b/tests/phpunit/Profile/AnimationAssemblyProfileTest.php
@@ -1,0 +1,371 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatScreenshot\Tests\Profile;
+
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Behat\Tester\Result\StepResult;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioInterface;
+use Behat\Gherkin\Node\StepNode;
+use Behat\Testwork\Environment\Environment;
+use Behat\Testwork\Tester\Result\TestResult;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Measure how long a scenario's animated GIF takes to assemble.
+ *
+ * Drives ScreenshotContext through the same hooks Behat calls, with the driver
+ * replaced by prepared images, and times the work separately for the steps and
+ * for the AfterScenario handler that builds the GIF. Each run is measured
+ * twice: with every frame the height of the viewport, and with one very long
+ * page among them, so the cost of a single tall capture is isolated from the
+ * cost inherent to encoding that many frames.
+ *
+ * Excluded from the default suite because it takes minutes to run. Invoke it
+ * with `composer profile`. Step counts can be overridden with
+ * BEHAT_SCREENSHOT_PROFILE_STEPS, e.g. `BEHAT_SCREENSHOT_PROFILE_STEPS=10,20`.
+ */
+#[CoversNothing]
+#[Group('profile')]
+class AnimationAssemblyProfileTest extends TestCase {
+
+  /**
+   * Width every captured frame shares, in pixels.
+   */
+  protected const FRAME_WIDTH = 1432;
+
+  /**
+   * Height of an ordinary viewport-sized capture, in pixels.
+   */
+  protected const VIEWPORT_HEIGHT = 900;
+
+  /**
+   * Height of the single long page, in pixels.
+   */
+  protected const LONG_PAGE_HEIGHT = 19090;
+
+  /**
+   * Step counts profiled when none are given in the environment.
+   */
+  protected const DEFAULT_STEPS = [25, 50, 100];
+
+  public function testAnimationAssemblyCost(): void {
+    $steps = $this->stepCounts();
+
+    $report = [
+      'Animated GIF assembly cost',
+      '==========================',
+      '',
+      sprintf('Frames are %dpx wide. "long page" runs replace one frame mid-scenario', self::FRAME_WIDTH),
+      sprintf('with a %dpx-tall capture, as always_fullscreen does on a long page.', self::LONG_PAGE_HEIGHT),
+      '',
+      sprintf('%-8s %-12s %9s %11s %9s %14s %14s', 'steps', 'tallest', 'steps_s', 'assembly_s', 'peak_mb', 'px_captured', 'px_encoded'),
+      str_repeat('-', 84),
+    ];
+
+    $rows = [];
+    foreach ([self::VIEWPORT_HEIGHT, self::LONG_PAGE_HEIGHT] as $tallest) {
+      foreach ($steps as $count) {
+        $row = $this->profile($count, $tallest);
+        $rows[$tallest][$count] = $row;
+        $report[] = $this->formatRow($row);
+      }
+    }
+
+    $report[] = '';
+    $report[] = 'Cost of one long page, at equal step counts:';
+    foreach ($steps as $count) {
+      $uniform = $rows[self::VIEWPORT_HEIGHT][$count];
+      $long = $rows[self::LONG_PAGE_HEIGHT][$count];
+      $report[] = sprintf(
+        '  %3d steps: %6.2fs -> %7.2fs (%.1fx), pixels encoded %.1fx what was captured',
+        $count,
+        $uniform['assembly'],
+        $long['assembly'],
+        $uniform['assembly'] > 0 ? $long['assembly'] / $uniform['assembly'] : 0,
+        $long['captured'] > 0 ? $long['encoded'] / $long['captured'] : 0
+      );
+    }
+    $report[] = '';
+
+    $this->writeReport(implode("\n", $report) . "\n");
+
+    // The measurement is only meaningful if the work really does happen at
+    // scenario end rather than during the steps.
+    foreach ($rows as $by_step) {
+      foreach ($by_step as $row) {
+        $this->assertGreaterThan($row['steps'], $row['assembly']);
+      }
+    }
+  }
+
+  /**
+   * Run one scenario and measure it.
+   *
+   * @param int $steps
+   *   Number of steps in the scenario.
+   * @param int $tallest
+   *   Height of the tallest captured frame, in pixels.
+   *
+   * @return array<string,float|int>
+   *   Timings, peak memory and pixel counts for the run.
+   */
+  protected function profile(int $steps, int $tallest): array {
+    $context = new ProfiledScreenshotContext();
+    $context->setScreenshotParameters('unused', TRUE, 'failed_', FALSE, FALSE, '{ext}', '{ext}', [], ['enabled' => TRUE, 'frame_delay' => 500]);
+
+    $before_scope = $this->beforeScenarioScope();
+    $after_step_scope = $this->afterStepScope();
+    $after_scenario_scope = $this->afterScenarioScope();
+
+    $viewport = $this->page(self::FRAME_WIDTH, self::VIEWPORT_HEIGHT);
+    $long = $tallest > self::VIEWPORT_HEIGHT ? $this->page(self::FRAME_WIDTH, $tallest) : $viewport;
+    $long_at = intdiv($steps, 2);
+
+    gc_collect_cycles();
+    memory_reset_peak_usage();
+    $baseline = memory_get_usage();
+
+    $context->beforeScenarioCheckScreenshotsTag($before_scope);
+
+    $started = hrtime(TRUE);
+    for ($step = 0; $step < $steps; $step++) {
+      $context->pending = $step === $long_at ? $long : $viewport;
+      $context->captureScreenshotAfterStep($after_step_scope);
+    }
+    $steps_elapsed = (hrtime(TRUE) - $started) / 1e9;
+    $context->pending = '';
+
+    $started = hrtime(TRUE);
+    $context->afterScenarioAnimate($after_scenario_scope);
+    $assembly_elapsed = (hrtime(TRUE) - $started) / 1e9;
+
+    $captured = ($steps - 1) * self::FRAME_WIDTH * self::VIEWPORT_HEIGHT + self::FRAME_WIDTH * $tallest;
+
+    return [
+      'steps_count' => $steps,
+      'tallest' => $tallest,
+      'steps' => $steps_elapsed,
+      'assembly' => $assembly_elapsed,
+      'peak' => (memory_get_peak_usage() - $baseline) / 1048576,
+      'captured' => $captured,
+      'encoded' => $this->encodedPixels($context->gif),
+      'bytes' => strlen($context->gif),
+    ];
+  }
+
+  /**
+   * Format one measured run as a report row.
+   *
+   * @param array<string,float|int> $row
+   *   Measurements for the run.
+   *
+   * @return string
+   *   Report line.
+   */
+  protected function formatRow(array $row): string {
+    return sprintf(
+      '%-8d %-12s %9.2f %11.2f %9.1f %14s %14s',
+      $row['steps_count'],
+      $row['tallest'] > self::VIEWPORT_HEIGHT ? 'long page' : 'viewport',
+      $row['steps'],
+      $row['assembly'],
+      $row['peak'],
+      number_format((float) $row['captured']),
+      number_format((float) $row['encoded'])
+    );
+  }
+
+  /**
+   * Render a page of the given size.
+   *
+   * @param int $width
+   *   Page width.
+   * @param int $height
+   *   Page height.
+   *
+   * @return string
+   *   Binary PNG data.
+   */
+  protected function page(int $width, int $height): string {
+    $image = imagecreatetruecolor(max(1, $width), max(1, $height));
+    imagefilledrectangle($image, 0, 0, $width - 1, $height - 1, (int) imagecolorallocate($image, 250, 250, 252));
+    imagefilledrectangle($image, 0, 0, $width - 1, 60, (int) imagecolorallocate($image, 28, 42, 88));
+
+    $ink = (int) imagecolorallocate($image, 40, 44, 60);
+    $muted = (int) imagecolorallocate($image, 150, 155, 170);
+
+    for ($y = 96; $y < $height - 30; $y += 26) {
+      $length = 300 + (($y * 7) % (int) ($width * 0.55));
+      imagefilledrectangle($image, 40, $y, 40 + $length, $y + 11, $ink);
+      imagefilledrectangle($image, 40, $y + 14, 40 + (int) ($length * 0.7), $y + 20, $muted);
+    }
+
+    ob_start();
+    imagepng($image);
+    $data = strval(ob_get_clean());
+    imagedestroy($image);
+
+    return $data;
+  }
+
+  /**
+   * Total the pixels every frame of a GIF stream encodes.
+   *
+   * @param string $gif
+   *   Binary GIF content.
+   *
+   * @return int
+   *   Sum of each image block's area, in pixels.
+   */
+  protected function encodedPixels(string $gif): int {
+    if (strlen($gif) < 14) {
+      return 0;
+    }
+
+    $packed = ord($gif[10]);
+    $offset = 13 + (($packed & 0x80) !== 0 ? 3 * (1 << (($packed & 0x07) + 1)) : 0);
+    $pixels = 0;
+
+    while ($offset < strlen($gif) && ord($gif[$offset]) !== 0x3B) {
+      $marker = ord($gif[$offset]);
+
+      if ($marker === 0x21) {
+        $offset = $this->skipSubBlocks($gif, $offset + 2);
+
+        continue;
+      }
+
+      if ($marker !== 0x2C) {
+        break;
+      }
+
+      $pixels += $this->readShort($gif, $offset + 5) * $this->readShort($gif, $offset + 7);
+
+      $image_packed = ord($gif[$offset + 9]);
+      $offset += 10 + (($image_packed & 0x80) !== 0 ? 3 * (1 << (($image_packed & 0x07) + 1)) : 0);
+      $offset = $this->skipSubBlocks($gif, $offset + 1);
+    }
+
+    return $pixels;
+  }
+
+  /**
+   * Read a little-endian unsigned short.
+   *
+   * @param string $data
+   *   Binary content.
+   * @param int $offset
+   *   Offset to read from.
+   *
+   * @return int
+   *   The decoded value.
+   */
+  protected function readShort(string $data, int $offset): int {
+    return ord($data[$offset]) + (ord($data[$offset + 1]) << 8);
+  }
+
+  /**
+   * Advance past a run of GIF data sub-blocks.
+   *
+   * @param string $data
+   *   GIF binary being scanned.
+   * @param int $offset
+   *   Offset of the first sub-block length byte.
+   *
+   * @return int
+   *   Offset immediately after the block terminator.
+   */
+  protected function skipSubBlocks(string $data, int $offset): int {
+    while (($length = ord($data[$offset])) !== 0) {
+      $offset += $length + 1;
+    }
+
+    return $offset + 1;
+  }
+
+  /**
+   * Read the step counts to profile.
+   *
+   * @return array<int,int>
+   *   Step counts.
+   */
+  protected function stepCounts(): array {
+    $configured = getenv('BEHAT_SCREENSHOT_PROFILE_STEPS');
+    if (!is_string($configured) || trim($configured) === '') {
+      return self::DEFAULT_STEPS;
+    }
+
+    $counts = array_values(array_filter(array_map('intval', explode(',', $configured)), static fn(int $count): bool => $count > 0));
+
+    return $counts === [] ? self::DEFAULT_STEPS : $counts;
+  }
+
+  /**
+   * Write the report where CI collects it.
+   *
+   * @param string $report
+   *   Report content.
+   */
+  protected function writeReport(string $report): void {
+    $dir = dirname(__DIR__, 3) . '/.logs/profile';
+    if (!is_dir($dir) && !mkdir($dir, 0755, TRUE) && !is_dir($dir)) {
+      throw new \RuntimeException(sprintf('Unable to create the profile directory %s.', $dir));
+    }
+
+    file_put_contents($dir . '/animation-assembly.txt', $report);
+    // Diagnostics go to STDERR so the strict no-output-during-tests rule that
+    // guards the default suite still holds.
+    fwrite(STDERR, $report);
+  }
+
+  /**
+   * Create a before scenario scope.
+   *
+   * @return \Behat\Behat\Hook\Scope\BeforeScenarioScope
+   *   Before scenario scope.
+   */
+  protected function beforeScenarioScope(): BeforeScenarioScope {
+    $feature = $this->createMock(FeatureNode::class);
+    $feature->method('hasTag')->willReturn(FALSE);
+    $scenario = $this->createMock(ScenarioInterface::class);
+    $scenario->method('hasTag')->willReturn(FALSE);
+
+    return new BeforeScenarioScope($this->createMock(Environment::class), $feature, $scenario);
+  }
+
+  /**
+   * Create an after step scope for a passed step.
+   *
+   * @return \Behat\Behat\Hook\Scope\AfterStepScope
+   *   After step scope.
+   */
+  protected function afterStepScope(): AfterStepScope {
+    $result = $this->createMock(StepResult::class);
+    $result->method('isPassed')->willReturn(TRUE);
+
+    return new AfterStepScope($this->createMock(Environment::class), $this->createMock(FeatureNode::class), $this->createMock(StepNode::class), $result);
+  }
+
+  /**
+   * Create an after scenario scope.
+   *
+   * @return \Behat\Behat\Hook\Scope\AfterScenarioScope
+   *   After scenario scope.
+   */
+  protected function afterScenarioScope(): AfterScenarioScope {
+    $feature = $this->createMock(FeatureNode::class);
+    $feature->method('getFile')->willReturn('profile.feature');
+    $scenario = $this->createMock(ScenarioInterface::class);
+    $scenario->method('getLine')->willReturn(1);
+
+    return new AfterScenarioScope($this->createMock(Environment::class), $feature, $scenario, $this->createMock(TestResult::class));
+  }
+
+}

--- a/tests/phpunit/Profile/ProfiledScreenshotContext.php
+++ b/tests/phpunit/Profile/ProfiledScreenshotContext.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrevOps\BehatScreenshot\Tests\Profile;
+
+use DrevOps\BehatScreenshotExtension\Context\ScreenshotContext;
+
+/**
+ * A screenshot context whose captures are supplied rather than driven.
+ *
+ * Standing in for the browser lets a scenario be replayed at any length
+ * without a running driver, while the hooks, the frame collection and the
+ * scenario-end assembly all remain the real ones.
+ */
+class ProfiledScreenshotContext extends ScreenshotContext {
+
+  /**
+   * Image data the next step captures.
+   */
+  public string $pending = '';
+
+  /**
+   * Content of the animated GIF written at the end of the scenario.
+   */
+  public string $gif = '';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function screenshot(array $options = []): void {
+    $this->lastScreenshotData = $this->pending;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function saveScreenshotContent(string $filename, string $content): void {
+    $this->gif = $content;
+  }
+
+}


### PR DESCRIPTION
Refs #241

## Summary

Adds a PHPUnit profiler that reproduces the memory and performance problem described in #241 and quantifies it with real numbers. It does not change any production code and does not fix the issue - it establishes a reproducible, quantified baseline that the fix in #242 can be measured against. #242 will be rebased onto this branch once this one merges.

The profiler replays a scenario of configurable length through `ScreenshotContext`'s real Behat hooks (`BeforeScenario`, `AfterStep` x N, `AfterScenario`), with the browser driver replaced by prepared images, and times the step phase separately from the `AfterScenario` handler that assembles the animated GIF.

## Changes

- `tests/phpunit/Profile/AnimationAssemblyProfileTest.php`: Replays a scenario of configurable length (default 25/50/100 steps, overridable via `BEHAT_SCREENSHOT_PROFILE_STEPS`) through `ScreenshotContext`'s real hooks, timing the step phase separately from GIF assembly. Reports step time, assembly time, peak memory, pixels captured and pixels encoded. Skips when `ext-gd` is unavailable.
- `tests/phpunit/Profile/ProfiledScreenshotContext.php`: A `ScreenshotContext` subclass that supplies prepared captures instead of driving a browser, so a scenario can be replayed at any length without a running driver while the hooks, frame collection and scenario-end assembly stay the real production code.
- `phpunit.xml`: Excludes the new `profile` group from the default suite, since a full run takes minutes.
- `composer.json`: Adds a `profile` script (`phpunit --group profile --no-coverage --do-not-cache-result`).
- `README.md`: Documents the `composer profile` command under Maintenance, including the `BEHAT_SCREENSHOT_PROFILE_STEPS` override.

## Results

Measured on this branch, against main's current encoder:

```
steps    tallest        steps_s  assembly_s   peak_mb    px_captured     px_encoded
------------------------------------------------------------------------------------
25       viewport          0.00        0.74       0.8     32,220,000     32,220,000
50       viewport          0.00        1.48       1.5     64,440,000     64,440,000
100      viewport          0.00        2.96       2.9    128,880,000    128,880,000
25       long page         0.00       17.48       2.5     58,268,080    683,422,000
50       long page         0.00       34.17       4.5     90,488,080  1,366,844,000
100      long page         0.00       67.78       8.6    154,928,080  2,733,688,000

Cost of one long page, at equal step counts:
   25 steps:   0.74s ->   17.48s (23.6x), pixels encoded 11.7x what was captured
   50 steps:   1.48s ->   34.17s (23.1x), pixels encoded 15.1x what was captured
  100 steps:   2.96s ->   67.78s (22.9x), pixels encoded 17.6x what was captured
```

Key findings:

- Step time is 0.00s in every row: the entire cost falls in the `AfterScenario` handler, so it presents as a stall after the scenario's last step, not as slower steps.
- One long page (a 19090px fullscreen capture, as in the report) makes a 100-step scenario's assembly 22.9x more expensive (2.96s to 67.78s). The other 99 frames are unchanged.
- Cost grows linearly with step count, so a 380-step scenario extrapolates to roughly 260s on this hardware, and several times that on a slower CI runner.
- The mechanism is visible in the last two columns: with uniform frames, pixels encoded equals pixels captured (1.0x); with one long page it reaches 17.6x, because every frame is padded up to the tallest frame's height before encoding.
- The viewport rows act as a control, isolating the defect from the cost inherent to encoding that many frames.

This PR changes no production code and adds no CI time - the `profile` group is excluded from the default suite, and `composer test` is unaffected.

## Before / After

```
Before: issue #241 is a qualitative report
────────────────────────────────────────────────────────────────
  Scenario (N steps) -> screenshots -> AfterScenario builds GIF
                                              │
                                              ▼
                                     "feels slow / uses a lot of
                                      memory" - no numbers, no
                                      reproducible case, no way
                                      to tell a fix worked.

After: quantified, reproducible baseline (this PR)
────────────────────────────────────────────────────────────────
  composer profile
        │
        ▼
  AnimationAssemblyProfileTest replays N steps through the real
  ScreenshotContext hooks, driver swapped for prepared images
        │
        ├── AfterStep x N            ──> steps_s   (0.00s, always)
        │
        └── AfterScenario (assemble) ──> assembly_s, peak_mb,
                                          px_captured, px_encoded
        │
        ▼
  .logs/profile/animation-assembly.txt (also a CI build artifact)
        "one 19090px page among 100 steps: assembly goes from
         2.96s to 67.78s (22.9x); pixels encoded reach 17.6x
         pixels captured, because every frame is padded up to
         the tallest frame's height before encoding."

  No production code changes. #242 (the fix) rebases onto this
  baseline and is judged against these same numbers.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added profiling for animated GIF assembly, including timing, memory, pixel, and output-size metrics.
  - Added configurable profiling scenarios for viewport-sized and long-page frames.
  - Profiling reports are saved to `.logs/profile/animation-assembly.txt`.
  - Added a Composer command to run profiling separately from the standard test suite.

- **Documentation**
  - Added instructions for running GIF assembly profiling and reviewing generated reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->