### PR TITLE
[#243] Added PHP 8.5 to the test matrix.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
 
     services:
       chrome:

--- a/src/DrevOps/BehatScreenshotExtension/AnimatedGif.php
+++ b/src/DrevOps/BehatScreenshotExtension/AnimatedGif.php
@@ -136,7 +136,6 @@ class AnimatedGif implements \Countable {
     // ob_get_clean() returns FALSE when no output buffer is active; strval()
     // maps that to the same empty string a failed encode produces.
     $gif = strval(ob_get_clean());
-    imagedestroy($image);
 
     // @codeCoverageIgnoreStart
     if ($gif === '') {
@@ -210,7 +209,7 @@ class AnimatedGif implements \Countable {
    * applies whether or not a maximum is configured.
    *
    * @param \GdImage $image
-   *   Source image. Destroyed once a cropped copy replaces it.
+   *   Source image.
    *
    * @return \GdImage
    *   The source image when it already fits, a cropped copy otherwise.
@@ -234,8 +233,6 @@ class AnimatedGif implements \Countable {
     }
 
     // @codeCoverageIgnoreEnd
-    imagedestroy($image);
-
     return $cropped;
   }
 

--- a/tests/phpunit/Functional/AnimationArtifactsTest.php
+++ b/tests/phpunit/Functional/AnimationArtifactsTest.php
@@ -193,9 +193,8 @@ class AnimationArtifactsTest extends TestCase {
 
     ob_start();
     imagepng($image);
-    $data = strval(ob_get_clean());
 
-    return $data;
+    return strval(ob_get_clean());
   }
 
   /**

--- a/tests/phpunit/Functional/AnimationArtifactsTest.php
+++ b/tests/phpunit/Functional/AnimationArtifactsTest.php
@@ -194,7 +194,6 @@ class AnimationArtifactsTest extends TestCase {
     ob_start();
     imagepng($image);
     $data = strval(ob_get_clean());
-    imagedestroy($image);
 
     return $data;
   }
@@ -214,7 +213,6 @@ class AnimationArtifactsTest extends TestCase {
   protected function writeConstrainedFrames(string $prefix, array $frames, int $max_width, int $max_height): void {
     $encoder = new AnimatedGif($max_width, $max_height);
     $constrain = new \ReflectionMethod($encoder, 'constrain');
-    $constrain->setAccessible(TRUE);
 
     foreach ($frames as $index => $frame) {
       $image = imagecreatefromstring($frame);
@@ -230,7 +228,6 @@ class AnimationArtifactsTest extends TestCase {
       ob_start();
       imagepng($result);
       $this->write(sprintf('%s-frame-%d.png', $prefix, $index + 1), strval(ob_get_clean()));
-      imagedestroy($result);
     }
   }
 

--- a/tests/phpunit/Profile/AnimationAssemblyProfileTest.php
+++ b/tests/phpunit/Profile/AnimationAssemblyProfileTest.php
@@ -238,9 +238,8 @@ class AnimationAssemblyProfileTest extends TestCase {
 
     ob_start();
     imagepng($image);
-    $data = strval(ob_get_clean());
 
-    return $data;
+    return strval(ob_get_clean());
   }
 
   /**

--- a/tests/phpunit/Profile/AnimationAssemblyProfileTest.php
+++ b/tests/phpunit/Profile/AnimationAssemblyProfileTest.php
@@ -239,7 +239,6 @@ class AnimationAssemblyProfileTest extends TestCase {
     ob_start();
     imagepng($image);
     $data = strval(ob_get_clean());
-    imagedestroy($image);
 
     return $data;
   }

--- a/tests/phpunit/Traits/ReflectionTrait.php
+++ b/tests/phpunit/Traits/ReflectionTrait.php
@@ -27,7 +27,7 @@ trait ReflectionTrait {
    * @return mixed
    *   Method result.
    */
-  protected static function callProtectedMethod(object|string $object, string $name, array $args = []) {
+  protected static function callProtectedMethod(object|string $object, string $name, array $args = []): mixed {
     $object_or_class = is_object($object) ? $object::class : $object;
 
     if (!class_exists($object_or_class)) {

--- a/tests/phpunit/Traits/ReflectionTrait.php
+++ b/tests/phpunit/Traits/ReflectionTrait.php
@@ -42,11 +42,6 @@ trait ReflectionTrait {
 
     $method = $class->getMethod($name);
 
-    $original_accessibility = $method->isPublic();
-
-    // Set method accessibility to true, so it can be invoked.
-    $method->setAccessible(TRUE);
-
     // If the method is static, we won't pass an object instance to invokeArgs()
     // Otherwise, we ensure to pass the object instance.
     $invoke_object = $method->isStatic() ? NULL : (is_object($object) ? $object : NULL);
@@ -56,12 +51,7 @@ trait ReflectionTrait {
       throw new \InvalidArgumentException("An object instance is required for non-static methods");
     }
 
-    $result = $method->invokeArgs($invoke_object, $args);
-
-    // Reset the method's accessibility to its original state.
-    $method->setAccessible($original_accessibility);
-
-    return $result;
+    return $method->invokeArgs($invoke_object, $args);
   }
 
   /**
@@ -77,7 +67,6 @@ trait ReflectionTrait {
   protected static function setProtectedValue($object, $property, mixed $value): void {
     $class = new \ReflectionClass($object::class);
     $property = $class->getProperty($property);
-    $property->setAccessible(TRUE);
 
     $property->setValue($object, $value);
   }
@@ -96,7 +85,6 @@ trait ReflectionTrait {
   protected static function getProtectedValue($object, $property): mixed {
     $class = new \ReflectionClass($object::class);
     $property = $class->getProperty($property);
-    $property->setAccessible(TRUE);
 
     return $property->getValue($class);
   }

--- a/tests/phpunit/Unit/AnimatedGifTest.php
+++ b/tests/phpunit/Unit/AnimatedGifTest.php
@@ -490,9 +490,7 @@ class AnimatedGifTest extends TestCase {
       return [0, 0];
     }
 
-    $size = [imagesx($image), imagesy($image)];
-
-    return $size;
+    return [imagesx($image), imagesy($image)];
   }
 
   /**

--- a/tests/phpunit/Unit/AnimatedGifTest.php
+++ b/tests/phpunit/Unit/AnimatedGifTest.php
@@ -333,7 +333,6 @@ class AnimatedGifTest extends TestCase {
     ob_start();
     imagepng($image);
     $frame = strval(ob_get_clean());
-    imagedestroy($image);
 
     $gif = (new AnimatedGif(0, 100))->encode([$frame], 100);
 
@@ -382,7 +381,6 @@ class AnimatedGifTest extends TestCase {
     ob_start();
     imagepng($image);
     $data = ob_get_clean();
-    imagedestroy($image);
 
     return (string) $data;
   }
@@ -414,7 +412,6 @@ class AnimatedGifTest extends TestCase {
     ob_start();
     imagepng($image);
     $data = ob_get_clean();
-    imagedestroy($image);
 
     return (string) $data;
   }
@@ -444,7 +441,6 @@ class AnimatedGifTest extends TestCase {
     ob_start();
     imagepng($image);
     $data = ob_get_clean();
-    imagedestroy($image);
 
     return (string) $data;
   }
@@ -495,7 +491,6 @@ class AnimatedGifTest extends TestCase {
     }
 
     $size = [imagesx($image), imagesy($image)];
-    imagedestroy($image);
 
     return $size;
   }
@@ -520,7 +515,6 @@ class AnimatedGifTest extends TestCase {
     }
 
     $colors = imagecolorsforindex($image, (int) imagecolorat($image, $x, $y));
-    imagedestroy($image);
 
     return [$colors['red'], $colors['green'], $colors['blue']];
   }

--- a/tests/phpunit/Unit/ScreenshotContextAnimationTest.php
+++ b/tests/phpunit/Unit/ScreenshotContextAnimationTest.php
@@ -294,7 +294,6 @@ class ScreenshotContextAnimationTest extends TestCase {
    */
   protected function getProtectedProperty(object $object, string $property): mixed {
     $reflection = new \ReflectionProperty($object, $property);
-    $reflection->setAccessible(TRUE);
 
     return $reflection->getValue($object);
   }

--- a/tests/phpunit/Unit/ScreenshotContextInfoTest.php
+++ b/tests/phpunit/Unit/ScreenshotContextInfoTest.php
@@ -80,7 +80,6 @@ class ScreenshotContextInfoTest extends TestCase {
     // Use reflection to access protected property.
     $reflection = new \ReflectionObject($screenshot_context);
     $info_property = $reflection->getProperty('info');
-    $info_property->setAccessible(TRUE);
     $info = $info_property->getValue($screenshot_context);
     $this->assertIsArray($info);
 
@@ -126,7 +125,6 @@ class ScreenshotContextInfoTest extends TestCase {
     // Use reflection to access protected property.
     $reflection = new \ReflectionObject($screenshot_context);
     $info_property = $reflection->getProperty('info');
-    $info_property->setAccessible(TRUE);
     $info = $info_property->getValue($screenshot_context);
     $this->assertIsArray($info);
 
@@ -172,7 +170,6 @@ class ScreenshotContextInfoTest extends TestCase {
     $screenshot_context = new ScreenshotContext();
     $reflection = new \ReflectionObject($screenshot_context);
     $method = $reflection->getMethod('getCurrentTime');
-    $method->setAccessible(TRUE);
 
     $time = $method->invoke($screenshot_context);
     $this->assertIsInt($time);
@@ -226,7 +223,6 @@ class ScreenshotContextInfoTest extends TestCase {
       // Access protected method.
       $reflection = new \ReflectionObject($screenshot_context);
       $method = $reflection->getMethod('makeFileName');
-      $method->setAccessible(TRUE);
 
       $result = $method->invokeArgs($screenshot_context, ['png', NULL, FALSE]);
       $this->assertIsString($result);

--- a/tests/phpunit/Unit/ScreenshotContextResizeTest.php
+++ b/tests/phpunit/Unit/ScreenshotContextResizeTest.php
@@ -78,7 +78,6 @@ class ScreenshotContextResizeTest extends TestCase {
     // Create reflection to test protected method.
     $reflection = new \ReflectionClass($screenshot_context);
     $method = $reflection->getMethod('getScreenshotFullscreenWithResize');
-    $method->setAccessible(TRUE);
 
     $result = $method->invoke($screenshot_context);
     $this->assertEquals('test-screenshot-data', $result);
@@ -125,7 +124,6 @@ class ScreenshotContextResizeTest extends TestCase {
     // Create reflection to test protected method.
     $reflection = new \ReflectionClass($screenshot_context);
     $method = $reflection->getMethod('getScreenshotFullscreenWithResize');
-    $method->setAccessible(TRUE);
 
     $result = $method->invoke($screenshot_context);
     $this->assertEquals('test-screenshot-data', $result);
@@ -158,7 +156,6 @@ class ScreenshotContextResizeTest extends TestCase {
     // Create reflection to access protected method.
     $reflection = new \ReflectionClass($screenshot_context);
     $method = $reflection->getMethod('getScreenshotFullscreen');
-    $method->setAccessible(TRUE);
 
     $result = $method->invoke($screenshot_context);
     $this->assertEquals('test-resize-screenshot-data', $result);

--- a/tests/phpunit/Unit/ScreenshotContextTest.php
+++ b/tests/phpunit/Unit/ScreenshotContextTest.php
@@ -179,7 +179,6 @@ class ScreenshotContextTest extends TestCase {
     );
     $screenshot_context_reflection = new \ReflectionClass($screenshot_context);
     $method = $screenshot_context_reflection->getMethod('saveScreenshotContent');
-    $method->setAccessible(TRUE);
     $method->invokeArgs($screenshot_context, [$filename, $data]);
     $filepath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $filename;
     $this->assertFileExists($filepath);
@@ -252,7 +251,6 @@ class ScreenshotContextTest extends TestCase {
 
     $screenshot_context_reflection = new \ReflectionClass($screenshot_context);
     $method = $screenshot_context_reflection->getMethod('makeFileName');
-    $method->setAccessible(TRUE);
     $filename_processed = $method->invokeArgs($screenshot_context, [$ext, $filename, $on_failed]);
 
     $this->assertEquals($expected, $filename_processed);


### PR DESCRIPTION
Closes #243

## Summary

PHP 8.5 joins the CI test matrix alongside 8.2, 8.3 and 8.4, and the calls it newly deprecates are removed. `imagedestroy()` and `Reflection*::setAccessible()` have been no-ops since PHP 8.0 and PHP 8.1 respectively, and the package floor is PHP 8.2, so deleting them is behaviour-preserving. Removing them left three methods with a redundant assign-then-return pattern and simplified one method body enough for static analysis to infer its return type, so this branch also carries the Rector cleanups (`SimplifyUselessVariableRector`, `ReturnTypeFromStrictTypedCallRector`) that keep `composer lint` green.

The suite was verified before pushing on PHP 8.5.9 in a container and on local PHP 8.4: 174 tests, 319 assertions, zero deprecation notices on both.

`composer.json` keeps its `>=8.2` floor and no 8.5-only syntax is used, so the supported range widens rather than shifts. The 8.3-only lint pin and the 8.2-only `drevops/phpcs-standard` removal in the workflow are untouched, and `composer.lock` is not regenerated - the locked set already resolves on 8.5, with `behat/behat` (`>=8.2 <8.6`) the tightest ceiling in it.

## Changes

### CI

- `.github/workflows/test.yml`: added `'8.5'` to the `php-versions` matrix, so 8.5 runs `composer validate`, `composer normalize --dry-run`, the PHPUnit suite with coverage, and the Behat BDD suite as a first-class, must-pass leg.

### Deprecated no-op calls removed

- `src/DrevOps/BehatScreenshotExtension/AnimatedGif.php`: dropped the `imagedestroy()` call after encoding a frame in `addFrame()` and the one after cropping in `constrain()`, and corrected the `constrain()` docblock, which claimed the source image was destroyed.
- `tests/phpunit/Traits/ReflectionTrait.php`: dropped the `setAccessible()` calls from `callProtectedMethod()`, `setProtectedValue()` and `getProtectedValue()`, along with the accessibility save/restore pair that only existed to undo the first call.
- `tests/phpunit/Unit/AnimatedGifTest.php`, `tests/phpunit/Unit/ScreenshotContextTest.php`, `tests/phpunit/Unit/ScreenshotContextInfoTest.php`, `tests/phpunit/Unit/ScreenshotContextResizeTest.php`, `tests/phpunit/Unit/ScreenshotContextAnimationTest.php`, `tests/phpunit/Functional/AnimationArtifactsTest.php`, `tests/phpunit/Profile/AnimationAssemblyProfileTest.php`: removed the same `imagedestroy()` and `setAccessible()` calls.

### Lint follow-through

- `tests/phpunit/Functional/AnimationArtifactsTest.php`, `tests/phpunit/Profile/AnimationAssemblyProfileTest.php`, `tests/phpunit/Unit/AnimatedGifTest.php`: collapsed the now single-use `$data` and `$size` variables into direct returns, which `SimplifyUselessVariableRector` began flagging once the `imagedestroy()` call between the assignment and the return was gone.
- `tests/phpunit/Traits/ReflectionTrait.php`: added the explicit `: mixed` return type to `callProtectedMethod()` that `ReturnTypeFromStrictTypedCallRector` can now infer from the simplified body.

## Before / After

```
┌─ Before ───────────────────────────────────────────────────┐
│ CI matrix:  ['8.2', '8.3', '8.4']                          │
│                                                            │
│ AnimatedGif::addFrame()                                    │
│   $gif = strval(ob_get_clean());                           │
│   imagedestroy($image);                                    │
│                                                            │
│ ReflectionTrait::callProtectedMethod()                     │
│   $original = $method->isPublic();                         │
│   $method->setAccessible(TRUE);                            │
│   $result = $method->invokeArgs($object, $args);           │
│   $method->setAccessible($original);                       │
│   return $result;                                          │
│                                                            │
│ AnimatedGifTest::firstFrameSize()                          │
│   $size = [imagesx($image), imagesy($image)];              │
│   imagedestroy($image);                                    │
│   return $size;                                            │
└────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─ After ────────────────────────────────────────────────────┐
│ CI matrix:  ['8.2', '8.3', '8.4', '8.5']                   │
│                                                            │
│ AnimatedGif::addFrame()                                    │
│   $gif = strval(ob_get_clean());                           │
│                                                            │
│ ReflectionTrait::callProtectedMethod()                     │
│   return $method->invokeArgs($object, $args);              │
│                                                            │
│ AnimatedGifTest::firstFrameSize()                          │
│   return [imagesx($image), imagesy($image)];               │
└────────────────────────────────────────────────────────────┘
```
