### PR TITLE
Updated scaffold to 1.2.0 and fixed the untested dependency lower bounds.

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(composer:*)",
+      "Bash(./vendor/bin/phpcs:*)",
+      "Bash(./vendor/bin/phpcbf:*)",
+      "Bash(./vendor/bin/phpstan:*)",
+      "Bash(./vendor/bin/rector:*)",
+      "Bash(./vendor/bin/phpunit:*)"
+    ]
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.php]
+indent_size = 2
+
 [*.{json,lock}]
 indent_size = 4
 
@@ -17,9 +20,6 @@ indent_size = 4
 indent_size = 2
 
 [*.yml.dist]
-indent_size = 2
-
-[*.{sh,bash,bats}]
 indent_size = 2
 
 [*.xml]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,4 @@
+# These are supported funding model platforms
+
 github: drevops
 patreon: drevops

--- a/.github/workflows/assign-author.yml
+++ b/.github/workflows/assign-author.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   assign-author:
+    name: Assign author
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -12,14 +12,33 @@ permissions:
 
 jobs:
   release-drafter:
+    name: Draft release notes
+    runs-on: ubuntu-latest
+
     permissions:
       contents: write
       pull-requests: write
 
-    runs-on: ubuntu-latest
-
     steps:
+      - name: Set version
+        id: version
+        env:
+          RELEASE_VERSION_SCHEME: ${{ vars.RELEASE_VERSION_SCHEME }}
+        run: |
+          SCHEME="${RELEASE_VERSION_SCHEME}"
+          if [ "${SCHEME}" = "calver" ]; then
+            VERSION="$(date "+%y.%-m").0"
+            echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+            echo "Using CalVer: ${VERSION}"
+          else
+            echo "Using SemVer (default)"
+          fi
+
       - name: Draft release notes
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
+        with:
+          tag: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
+          version: ${{ steps.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,14 @@ permissions:
 
 jobs:
   test:
-    name: PHP ${{ matrix.php-versions }}
+    name: PHP ${{ matrix.php-versions }}, Deps ${{ matrix.deps }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         php-versions: ['8.2', '8.3', '8.4', '8.5']
+        deps: ['normal', 'lowest']
 
     services:
       chrome:
@@ -45,7 +46,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-${{ matrix.deps }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -60,7 +61,11 @@ jobs:
           if [ "${{ matrix.php-versions }}" == "8.2" ]; then
             composer remove --dev drevops/phpcs-standard --no-update
           fi
-          composer install
+          if [ "${{ matrix.deps }}" == "lowest" ]; then
+            composer update --prefer-lowest --prefer-stable
+          else
+            composer install
+          fi
 
       - name: Validate composer.json
         run: |
@@ -68,7 +73,7 @@ jobs:
           composer normalize --dry-run
 
       - name: Check coding standards
-        if: matrix.php-versions == '8.3'
+        if: matrix.php-versions == '8.3' && matrix.deps == 'normal'
         run: composer lint
         continue-on-error: ${{ vars.CI_LINT_IGNORE_FAILURE == '1' }}
 
@@ -92,14 +97,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{github.job}}-logs-${{ matrix.php-versions }}
+          name: ${{github.job}}-logs-${{ matrix.php-versions }}-${{ matrix.deps }}
           path: .logs
           include-hidden-files: true
           if-no-files-found: error
 
       - name: Upload test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.deps == 'normal' && env.CODECOV_TOKEN != '' }}
         with:
           files: .logs/junit.xml
           report_type: test_results
@@ -109,7 +114,7 @@ jobs:
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.deps == 'normal' && env.CODECOV_TOKEN != '' }}
         with:
           files: |
             .logs/coverage/behat/cobertura.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,16 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    name: PHP ${{ matrix.php-versions }}
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.2', '8.3', '8.4', '8.5']
 
@@ -33,6 +38,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Cache Composer dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -89,6 +96,16 @@ jobs:
           path: .logs
           include-hidden-files: true
           if-no-files-found: error
+
+      - name: Upload test results to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        with:
+          files: .logs/junit.xml
+          report_type: test_results
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,22 @@
 # To ignore OS temporary files use global .gitignore
 # https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer
 
-/.build
-/.coverage-html
-/.logs
 /.phpunit.cache
-/cobertura.xml
 /composer.lock
-/docker-compose.override.yml
-/screenshots
 /vendor
+/vendor-bin
+
+# Code coverage and test logs.
+/.logs
+
+# Screenshots captured by the default behat.yml.dist configuration.
+/screenshots
+
+# Temporary AI agent and developer artifacts (plans, scratch output, reports).
+/.artifacts/
+
+# Claude Code settings are shared; personal overrides stay local.
+!/.claude/
+/.claude/settings.local.json
+# Claude Code fetches the project update skill on demand; do not commit it.
+/.claude/skills/update-consumer-scaffold/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,56 @@
 
 Thank you for considering a contribution to this project. This guide covers setting up a local environment and running the linting and tests.
 
-    composer install
-    composer lint
-    composer test
-    composer test-bdd
+## Setup
+
+```shell
+composer install
+```
+
+## Linting
+
+```shell
+composer lint      # Check coding standards, run static analysis and lint feature files.
+composer lint-fix  # Apply the fixes Rector and PHPCBF can make automatically.
+```
+
+## Tests
+
+```shell
+composer test           # Run unit tests without coverage.
+composer test-coverage  # Run unit tests with coverage.
+```
+
+### BDD tests
+
+There are tests for Selenium and Headless drivers. Selenium requires a Docker container and headless requires a Chromium browser.
+
+```shell
+# Start Chromium in container for Selenium-based tests.
+docker run -d -p 4444:4444 -p 9222:9222 selenium/standalone-chromium
+
+# Install Chromium with brew.
+brew cask install chromedriver
+# Launch Chromium with remote debugging.
+/opt/homebrew/Caskroom/chromium/latest/chromium.wrapper.sh --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
+```
+
+```shell
+composer test-bdd  # Run BDD tests.
+
+BEHAT_CLI_DEBUG=1 composer test-bdd  # Run BDD tests with debug output.
+```
+
+### Profiling animated GIF assembly
+
+Building a scenario's animated GIF happens in the `AfterScenario` handler, so its cost lands as a pause after the scenario's last step rather than as slower steps. The profiler replays a scenario of a given length through the real hooks and reports how long each phase took, how much memory peaked, and how many pixels were encoded compared to how many were captured.
+
+It is excluded from `composer test` because it takes minutes to run.
+
+```shell
+composer profile  # Profile 25, 50 and 100-step scenarios.
+
+BEHAT_SCREENSHOT_PROFILE_STEPS=10,20 composer profile  # Profile other lengths.
+```
+
+The report is printed and written to `.logs/profile/animation-assembly.txt`, which CI collects as a build artifact.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,9 @@ There are tests for Selenium and Headless drivers. Selenium requires a Docker co
 docker run -d -p 4444:4444 -p 9222:9222 selenium/standalone-chromium
 
 # Install Chromium with brew.
-brew cask install chromedriver
+brew install --cask chromium
 # Launch Chromium with remote debugging.
-/opt/homebrew/Caskroom/chromium/latest/chromium.wrapper.sh --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
+"$(brew --prefix)/bin/chromium" --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
 ```
 
 ```shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+Thank you for considering a contribution to this project. This guide covers setting up a local environment and running the linting and tests.
+
+    composer install
+    composer lint
+    composer test
+    composer test-bdd

--- a/README.md
+++ b/README.md
@@ -295,51 +295,9 @@ public function beforeScenarioUpdateBaseUrl(BeforeScenarioScope $scope): void {
 }
 ```
 
-## Maintenance
+## Contributing
 
-```shell
-composer install
-composer lint
-composer lint-fix
-composer test-unit
-composer test-bdd
-```
-
-### Profiling animated GIF assembly
-
-Building a scenario's animated GIF happens in the `AfterScenario` handler, so its cost lands as a pause after the scenario's last step rather than as slower steps. The profiler replays a scenario of a given length through the real hooks and reports how long each phase took, how much memory peaked, and how many pixels were encoded compared to how many were captured.
-
-It is excluded from `composer test` because it takes minutes to run.
-
-```shell
-composer profile  # Profile 25, 50 and 100-step scenarios.
-
-BEHAT_SCREENSHOT_PROFILE_STEPS=10,20 composer profile  # Profile other lengths.
-```
-
-The report is printed and written to `.logs/profile/animation-assembly.txt`, which CI collects as a build artifact.
-
-### BDD tests
-
-There are tests for Selenium and Headless drivers. Selenium requires a Docker
-container and headless requires a Chromium browser (we will make this more
-streamlined in the future).
-
-```shell
-# Start Chromium in container for Selenium-based tests.
-docker run -d -p 4444:4444 -p 9222:9222 selenium/standalone-chromium
-
-# Install Chromium with brew.
-brew cask install chromedriver
-# Launch Chromium with remote debugging.
-/opt/homebrew/Caskroom/chromium/latest/chromium.wrapper.sh --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
-```
-
-```shell
-composer test-bdd  # Run BDD tests.
-
-BEHAT_CLI_DEBUG=1 composer test-bdd  # Run BDD tests with debug output.
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, linting, unit and BDD tests, and the animated GIF assembly profiler.
 
 ---
 _Repository created using https://getscaffold.dev/ project scaffold template_

--- a/composer.json
+++ b/composer.json
@@ -18,27 +18,28 @@
     },
     "require": {
         "php": ">=8.2",
-        "behat/behat": "^3.13.0",
-        "friends-of-behat/mink-extension": "^2.7",
+        "behat/behat": "^3.32.0",
+        "behat/mink": "^1.13",
+        "friends-of-behat/mink-extension": "^2.7.5",
         "symfony/finder": "^6.4 || ^7.0",
         "symfony/http-client": "^6.4 || ^7.0"
     },
     "require-dev": {
-        "behat/mink-browserkit-driver": "^2.2",
+        "behat/mink-browserkit-driver": "^2.3",
         "dantleech/gherkin-lint": "^0.2.3",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
-        "dmore/behat-chrome-extension": "^1.4",
-        "drevops/behat-phpserver": "^2.0",
+        "dmore/behat-chrome-extension": "^1.4.1",
+        "drevops/behat-phpserver": "^2.3",
         "drevops/phpcs-standard": "^0.7",
         "drupal/coder": "^9.0.1",
         "dvdoug/behat-code-coverage": "^5.3.7",
         "ergebnis/composer-normalize": "^2.52.0",
-        "lullabot/mink-selenium2-driver": "^1.7",
-        "lullabot/php-webdriver": "^2.0.4",
+        "lullabot/mink-selenium2-driver": "^1.7.4",
+        "lullabot/php-webdriver": "^2.0.7",
         "phpstan/phpstan": "^2.2.8",
         "phpunit/phpunit": "^11.5.56",
         "rector/rector": "^2.6.2",
-        "symfony/process": "^6.4 || ^7.0"
+        "symfony/process": "^7.0"
     },
     "suggest": {
         "ext-gd": "Required to generate animated GIF screenshots (the animation option)."

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "dantleech/gherkin-lint": "^0.2.3",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
         "dmore/behat-chrome-extension": "^1.4.1",
+        "dmore/chrome-mink-driver": "^2.10",
         "drevops/behat-phpserver": "^2.3",
         "drevops/phpcs-standard": "^0.7",
         "drupal/coder": "^9.0.1",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "behat/behat": "^3.13.0",
         "friends-of-behat/mink-extension": "^2.7",
         "symfony/finder": "^6.4 || ^7.0",
-        "symfony/http-client": "^6.0 || ^7.0"
+        "symfony/http-client": "^6.4 || ^7.0"
     },
     "require-dev": {
         "behat/mink-browserkit-driver": "^2.2",
@@ -31,7 +31,7 @@
         "drevops/behat-phpserver": "^2.0",
         "drevops/phpcs-standard": "^0.7",
         "drupal/coder": "^9.0.1",
-        "dvdoug/behat-code-coverage": "^5.3",
+        "dvdoug/behat-code-coverage": "^5.3.7",
         "ergebnis/composer-normalize": "^2.52.0",
         "lullabot/mink-selenium2-driver": "^1.7",
         "lullabot/php-webdriver": "^2.0.4",

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
             "role": "Maintainer"
         }
     ],
+    "homepage": "https://github.com/drevops/behat-screenshot",
+    "support": {
+        "issues": "https://github.com/drevops/behat-screenshot/issues",
+        "source": "https://github.com/drevops/behat-screenshot"
+    },
     "require": {
         "php": ">=8.2",
         "behat/behat": "^3.13.0",
@@ -21,23 +26,25 @@
     "require-dev": {
         "behat/mink-browserkit-driver": "^2.2",
         "dantleech/gherkin-lint": "^0.2.3",
-        "dealerdirect/phpcodesniffer-composer-installer": "^1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
         "dmore/behat-chrome-extension": "^1.4",
         "drevops/behat-phpserver": "^2.0",
-        "drevops/phpcs-standard": "^0.7.0",
-        "drupal/coder": "^9.0",
+        "drevops/phpcs-standard": "^0.7",
+        "drupal/coder": "^9.0.1",
         "dvdoug/behat-code-coverage": "^5.3",
-        "ergebnis/composer-normalize": "^2.44",
+        "ergebnis/composer-normalize": "^2.52.0",
         "lullabot/mink-selenium2-driver": "^1.7",
         "lullabot/php-webdriver": "^2.0.4",
-        "phpstan/phpstan": "^2",
-        "phpunit/phpunit": "^11",
-        "rector/rector": "^2",
+        "phpstan/phpstan": "^2.2.8",
+        "phpunit/phpunit": "^11.5.56",
+        "rector/rector": "^2.6.2",
         "symfony/process": "^6.4 || ^7.0"
     },
     "suggest": {
         "ext-gd": "Required to generate animated GIF screenshots (the animation option)."
     },
+    "minimum-stability": "stable",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "DrevOps\\BehatScreenshotExtension\\": "src/DrevOps/BehatScreenshotExtension"
@@ -52,6 +59,16 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "ergebnis/composer-normalize": true
+        },
+        "discard-changes": true,
+        "policy": {
+            "advisories": {
+                "block": false,
+                "audit": "fail"
+            },
+            "abandoned": {
+                "audit": "report"
+            }
         },
         "sort-packages": true
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
@@ -11,7 +12,8 @@
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerNotices="true"
-         displayDetailsOnTestsThatTriggerDeprecations="true">
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnPhpunitDeprecations="true">
     <testsuites>
         <testsuite name="default">
             <directory>tests/phpunit</directory>
@@ -29,13 +31,20 @@
         <include>
             <directory>src</directory>
         </include>
+        <exclude>
+            <directory>tests</directory>
+        </exclude>
     </source>
     <coverage includeUncoveredFiles="true"
               ignoreDeprecatedCodeUnits="true"
               disableCodeCoverageIgnore="false">
         <report>
             <html outputDirectory=".logs/coverage/phpunit/.coverage-html" lowUpperBound="50" highLowerBound="90"/>
+            <text outputFile=".logs/coverage/phpunit/coverage.txt"/>
             <cobertura outputFile=".logs/coverage/phpunit/cobertura.xml"/>
         </report>
     </coverage>
+    <logging>
+        <junit outputFile=".logs/junit.xml"/>
+    </logging>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -6,48 +6,62 @@
  *
  * Usage:
  * ./vendor/bin/rector process .
- *
- * @see https://github.com/palantirnet/drupal-rector/blob/main/rector.php
  */
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
+use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
+use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
-use Rector\Set\ValueObject\SetList;
+use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
+use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
+use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
+use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
-return static function (RectorConfig $rectorConfig): void {
-  $rectorConfig->paths([
+return RectorConfig::configure()
+  ->withPaths([
     __DIR__ . '/**',
-  ]);
-
-  $rectorConfig->sets([
-    SetList::PHP_82,
-    SetList::CODE_QUALITY,
-    SetList::CODING_STYLE,
-    SetList::DEAD_CODE,
-    SetList::INSTANCEOF,
-    SetList::TYPE_DECLARATION,
-  ]);
-
-  $rectorConfig->rule(DeclareStrictTypesRector::class);
-
-  $rectorConfig->skip([
+  ])
+  ->withPhpSets(php82: TRUE)
+  ->withPreparedSets(
+    deadCode: TRUE,
+    codeQuality: TRUE,
+    codingStyle: TRUE,
+    typeDeclarations: TRUE,
+    naming: TRUE,
+    instanceOf: TRUE,
+    earlyReturn: TRUE,
+    phpunitCodeQuality: TRUE,
+  )
+  ->withComposerBased(phpunit: TRUE)
+  ->withRules([
+    DeclareStrictTypesRector::class,
+  ])
+  ->withSkip([
     // Rules added by Rector's rule sets.
+    CatchExceptionNameMatchingTypeRector::class,
+    ChangeSwitchToMatchRector::class,
+    CompleteDynamicPropertiesRector::class,
     CountArrayToEmptyArrayComparisonRector::class,
     DisallowedEmptyRuleFixerRector::class,
     InlineArrayReturnAssignRector::class,
     NewlineAfterStatementRector::class,
     NewlineBeforeNewAssignSetRector::class,
+    NewlineBetweenClassLikeStmtsRector::class,
     RemoveAlwaysTrueIfConditionRector::class,
+    RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
+    RenameVariableToMatchMethodCallReturnTypeRector::class,
+    RenameVariableToMatchNewTypeRector::class,
     SimplifyEmptyCheckOnEmptyArrayRector::class,
     // Rector infers ob_get_clean() as string, but it returns string|false
     // when no buffer is active. The cast is what maps that FALSE onto the
@@ -62,13 +76,9 @@ return static function (RectorConfig $rectorConfig): void {
     '*/vendor/*',
     '*/node_modules/*',
     'tests/behat/bootstrap/BehatCliContext.php',
-  ]);
-
-  $rectorConfig->fileExtensions([
+  ])
+  ->withFileExtensions([
     'php',
     'inc',
-  ]);
-
-  $rectorConfig->importNames(TRUE, FALSE);
-  $rectorConfig->importShortClasses(FALSE);
-};
+  ])
+  ->withImportNames(importNames: TRUE, importDocBlockNames: FALSE, importShortClasses: FALSE);

--- a/rector.php
+++ b/rector.php
@@ -16,16 +16,11 @@ use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
-use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
-use Rector\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector;
-use Rector\Naming\Rector\ClassMethod\RenameVariableToMatchNewTypeRector;
-use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
-use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
 return RectorConfig::configure()
@@ -38,12 +33,8 @@ return RectorConfig::configure()
     codeQuality: TRUE,
     codingStyle: TRUE,
     typeDeclarations: TRUE,
-    naming: TRUE,
     instanceOf: TRUE,
-    earlyReturn: TRUE,
-    phpunitCodeQuality: TRUE,
   )
-  ->withComposerBased(phpunit: TRUE)
   ->withRules([
     DeclareStrictTypesRector::class,
   ])
@@ -52,16 +43,11 @@ return RectorConfig::configure()
     CatchExceptionNameMatchingTypeRector::class,
     ChangeSwitchToMatchRector::class,
     CompleteDynamicPropertiesRector::class,
-    CountArrayToEmptyArrayComparisonRector::class,
-    DisallowedEmptyRuleFixerRector::class,
     InlineArrayReturnAssignRector::class,
     NewlineAfterStatementRector::class,
     NewlineBeforeNewAssignSetRector::class,
     NewlineBetweenClassLikeStmtsRector::class,
     RemoveAlwaysTrueIfConditionRector::class,
-    RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class,
-    RenameVariableToMatchMethodCallReturnTypeRector::class,
-    RenameVariableToMatchNewTypeRector::class,
     SimplifyEmptyCheckOnEmptyArrayRector::class,
     // Rector infers ob_get_clean() as string, but it returns string|false
     // when no buffer is active. The cast is what maps that FALSE onto the

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,21 @@
 {
     "extends": ["config:recommended"],
     "automerge": true,
+    "rangeStrategy": "bump",
     "dependencyDashboard": true,
     "pinDigests": true,
     "branchPrefix": "deps/",
-    "enabledManagers": ["github-actions"],
     "packageRules": [
+        {
+            "matchDepNames": ["php"],
+            "matchManagers": ["composer"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["composer"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
         {
             "matchPackageNames": ["*"],
             "groupName": "all dependencies",

--- a/src/DrevOps/BehatScreenshotExtension/AnimatedGif.php
+++ b/src/DrevOps/BehatScreenshotExtension/AnimatedGif.php
@@ -92,7 +92,7 @@ class AnimatedGif implements \Countable {
    *   Binary content of the animated GIF.
    */
   public function encode(array $frames, int $frame_delay): string {
-    $frames = array_values(array_filter($frames, 'is_string'));
+    $frames = array_values(array_filter($frames, is_string(...)));
 
     if ($frames === []) {
       throw new \InvalidArgumentException('At least one frame is required to build an animated GIF.');

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -208,7 +208,7 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
 
       $this->getSession()->resizeWindow(self::DEFAULT_WINDOW_WIDTH, self::DEFAULT_WINDOW_HEIGHT, self::WINDOW_NAME_CURRENT);
     }
-    catch (UnsupportedDriverActionException $exception) {
+    catch (UnsupportedDriverActionException) {
       // Drivers without visual screenshot support do not have them created.
     }
     catch (DriverException $exception) {

--- a/tests/behat/bootstrap/ScreenshotTrait.php
+++ b/tests/behat/bootstrap/ScreenshotTrait.php
@@ -93,7 +93,7 @@ trait ScreenshotTrait {
     $files = glob($this->screenshotDir . DIRECTORY_SEPARATOR . '*');
 
     if (!empty($files)) {
-      array_map('unlink', $files);
+      array_map(unlink(...), $files);
     }
   }
 

--- a/tests/behat/features/screenshot_behatcli.feature
+++ b/tests/behat/features/screenshot_behatcli.feature
@@ -424,9 +424,9 @@ Feature: Screenshot context
 
   # Test for a headless browser using behat-chrome/behat-chrome-extension driver.
   # @see https://gitlab.com/behat-chrome/behat-chrome-extension
-  # Install Chromium with brew: `brew cask install chromedriver`
-  # Launch chrome: /opt/homebrew/Caskroom/chromium/latest/chromium.wrapper.sh --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
-  # Note: this test does not use the Docker container. See README.md for more information.
+  # Install Chromium with brew: `brew install --cask chromium`
+  # Launch chrome: "$(brew --prefix)/bin/chromium" --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
+  # Note: this test does not use the Docker container. See CONTRIBUTING.md for more information.
   @headless
   Scenario: Test Screenshot context using behat-chrome/behat-chrome-extension
     Given screenshot fixture

--- a/tests/phpunit/Profile/AnimationAssemblyProfileTest.php
+++ b/tests/phpunit/Profile/AnimationAssemblyProfileTest.php
@@ -252,7 +252,7 @@ class AnimationAssemblyProfileTest extends TestCase {
       return self::DEFAULT_STEPS;
     }
 
-    $counts = array_values(array_filter(array_map('intval', explode(',', $configured)), static fn(int $count): bool => $count > 0));
+    $counts = array_values(array_filter(array_map(intval(...), explode(',', $configured)), static fn(int $count): bool => $count > 0));
 
     return $counts === [] ? self::DEFAULT_STEPS : $counts;
   }


### PR DESCRIPTION
## Summary

Updates the project infrastructure from the [Scaffold](https://getscaffold.dev/) template release `0.12.1` to `1.2.0`. The template was re-initialised with this project's detected options and the project's own code and configuration restored on top, so only template-managed infrastructure changed.

The update also adds a `lowest` dependency dimension to the CI matrix. That dimension immediately failed, which exposed a set of declared lower bounds that were never installable or never worked on the supported PHP versions. Those bounds are now raised to versions the suite actually exercises, and one genuinely undeclared runtime dependency is now declared.

## Changes

### Dependencies

- `behat/mink` is now declared in `require`. `ScreenshotContext` uses `Behat\Mink` directly but the package had been relying on it arriving transitively through `friends-of-behat/mink-extension`.
- Lower bounds raised to versions the test suite actually passes on: `behat/behat`, `friends-of-behat/mink-extension`, `behat/mink-browserkit-driver`, `dmore/behat-chrome-extension`, `dmore/chrome-mink-driver`, `drevops/behat-phpserver`, `dvdoug/behat-code-coverage`, `lullabot/mink-selenium2-driver`, `lullabot/php-webdriver`, `symfony/http-client` and `symfony/process`.
- `composer.json` is otherwise a three-way merge: the project keeps its identity, `require`, `autoload`, `suggest` and scripts, while taking the template's refreshed dev-dependency constraints and its new `homepage`, `support`, `minimum-stability`, `prefer-stable`, `config.discard-changes` and `config.policy` blocks.

### Continuous integration

- `test.yml` gains a `deps` dimension of `normal` and `lowest`, so the matrix now runs both dependency sets across PHP 8.2, 8.3, 8.4 and 8.5. Linting and the Codecov uploads are pinned to the `normal` leg so coverage is not reported twice.
- `test.yml` picks up the template's hardening: a workflow-level `permissions: contents: read`, `persist-credentials: false` on checkout, `fail-fast: false`, a job name and a junit test-results upload to Codecov.
- `draft-release-notes.yml` gains optional CalVer support driven by a repository variable, defaulting to SemVer as before. `assign-author.yml` and `FUNDING.yml` receive cosmetic updates from the template.

### Tooling configuration

- `rector.php` moves to the template's fluent `RectorConfig::configure()` API. The rule sets are deliberately kept aligned with the project's previous set list rather than adopting the template's `naming`, `earlyReturn`, `phpunitCodeQuality` and `withComposerBased(phpunit)` sets, which would rename parameters, convert array data providers to generators and finalise test classes across 16 files. It targets PHP 8.2, the project's floor, rather than the template's 8.3.
- Four source changes follow from the Rector upgrade: first-class callable syntax in `AnimatedGif.php`, `ScreenshotTrait.php` and `AnimationAssemblyProfileTest.php`, and an unused catch variable removed in `ScreenshotContext.php`.
- `phpunit.xml` takes the template's XML declaration, `displayDetailsOnPhpunitDeprecations`, source `exclude`, text coverage report and junit logging, while keeping the project's 11.5 schema, `profile` group exclusion, `includeUncoveredFiles` and the `.logs/coverage/phpunit/` output paths that CI consumes.
- `phpcs.xml` and `phpstan.neon` are unchanged: the template versions dropped exclusions this project needs and added nothing.
- `.editorconfig` takes the template's `[*.php]` rule and keeps the project's `[*.feature]` and `[*.yml.dist]` rules. `.gitignore` picks up `/vendor-bin`, `/.artifacts/` and the `.claude` handling, which makes `.claude/settings.json` a tracked shared file while keeping `settings.local.json` local.

### Documentation

- Contributor material moves out of `README.md` into a new `CONTRIBUTING.md`: setup, linting, unit and BDD test commands, the Selenium and headless browser setup, and the animated GIF assembly profiler. `README.md` keeps a pointer.
- The documented unit test command is corrected from `composer test-unit`, which does not exist, to `composer test`.
- The headless browser instructions now install Chromium rather than ChromeDriver. `dmore/behat-chrome-extension` connects straight to Chromium's DevTools endpoint and never uses ChromeDriver. The duplicate instructions in `screenshot_behatcli.feature` are corrected to match.

### Not carried over from the template

- `release-php.yml` is omitted. With PHAR disabled its build step is stripped, leaving an empty `files:` list and an unset `RELEASE_VERSION`, so it cannot run. This library releases through Packagist tags.
- The generic `test-php.yml` is omitted because it would duplicate `test.yml` while dropping the Chrome and Selenium services, the `gd` extension, the PHP 8.2 matrix entry and the BDD run. Its useful parts were folded into `test.yml` instead.
- The generated `AGENTS.md` is omitted because it documented a Symfony Console application with `src/Command/`, a `behat-screenshot` entry point and a `DrevOps\App\` namespace, none of which exist in this library. `CLAUDE.md` remains the accurate agent guidance.

### Behaviour change to note

`renovate.json` no longer restricts `enabledManagers` to `github-actions`, so Renovate will now also raise Composer dependency pull requests. Major updates and `php` itself remain excluded.

## Before / After

```
CI matrix
┌────────────────────────────┐      ┌────────────────────────────────────────┐
│ BEFORE                     │      │ AFTER                                  │
│                            │      │                                        │
│  PHP 8.2 ─┐                │      │  PHP 8.2 ─┬─ deps: normal              │
│  PHP 8.3 ─┼─ deps: normal  │ ───► │           └─ deps: lowest              │
│  PHP 8.4 ─┤   (implicit)   │      │  PHP 8.3 ─┬─ deps: normal              │
│  PHP 8.5 ─┘                │      │           └─ deps: lowest              │
│                            │      │  PHP 8.4 ─┬─ deps: normal              │
│  4 jobs                    │      │           └─ deps: lowest              │
│                            │      │  PHP 8.5 ─┬─ deps: normal              │
│                            │      │           └─ deps: lowest              │
│                            │      │                                        │
│                            │      │  8 jobs                                │
└────────────────────────────┘      └────────────────────────────────────────┘

Declared lower bounds
┌────────────────────────────┐      ┌────────────────────────────────────────┐
│ BEFORE                     │      │ AFTER                                  │
│                            │      │                                        │
│  composer.json floors      │      │  composer.json floors                  │
│    never resolved          │ ───► │    resolved and run every build        │
│    never installed         │      │    install cleanly on PHP 8.2 - 8.5    │
│    never tested            │      │    full unit and BDD suites pass       │
│                            │      │                                        │
│  behat/mink used in src/   │      │  behat/mink declared in require        │
│    but undeclared          │      │                                        │
└────────────────────────────┘      └────────────────────────────────────────┘
```
