### PR TITLE
[#264] Added a tag and an environment variable to disable animated screenshots.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,15 +191,24 @@ Scenario: Long workflow that should not be recorded
   # No animated GIF is written, and no per-step screenshots are captured for it.
 ```
 
+To turn animation off for a whole run without editing feature files or configuration - on a CI job that only needs the per-step screenshots, for example - set the `BEHAT_SCREENSHOT_ANIMATION_SKIP` environment variable to a truthy value:
+
+```bash
+BEHAT_SCREENSHOT_ANIMATION_SKIP=1 vendor/bin/behat
+```
+
+This overrides everything below it, including `@screenshots:animated` tags, so no scenario in the run is animated.
+
 Tags are resolved from the most specific scope down, so a scenario tag decides on its own, a feature tag applies only when the scenario carries neither tag, and `animation.enabled` applies only when neither scope is tagged:
 
-| Scenario tag                   | Feature tag                    | `animation.enabled` | Animated |
-|--------------------------------|--------------------------------|---------------------|----------|
-| `@screenshots:animated:skip`   | -                              | `true`              | No       |
-| `@screenshots:animated`        | `@screenshots:animated:skip`   | `false`             | Yes      |
-| `@screenshots:animated:skip`   | `@screenshots:animated`        | `true`              | No       |
-| -                              | `@screenshots:animated:skip`   | `true`              | No       |
-| -                              | -                              | `true`              | Yes      |
+| `BEHAT_SCREENSHOT_ANIMATION_SKIP` | Scenario tag                   | Feature tag                    | `animation.enabled` | Animated |
+|-----------------------------------|--------------------------------|--------------------------------|---------------------|----------|
+| `1`                               | `@screenshots:animated`        | -                              | `false`             | No       |
+| unset                             | `@screenshots:animated:skip`   | -                              | `true`              | No       |
+| unset                             | `@screenshots:animated`        | `@screenshots:animated:skip`   | `false`             | Yes      |
+| unset                             | `@screenshots:animated:skip`   | `@screenshots:animated`        | `true`              | No       |
+| unset                             | -                              | `@screenshots:animated:skip`   | `true`              | No       |
+| unset                             | -                              | -                              | `true`              | Yes      |
 
 A scenario or feature carrying both tags at once is not animated - the skip tag wins within a scope.
 
@@ -227,7 +236,7 @@ Frames larger than the cap are cropped to it before being encoded, keeping the t
 | `dir`                     | `%paths.base%/screenshots`                                             | Path to directory to save screenshots. Directory structure will be created if the directory does not exist. Override with `BEHAT_SCREENSHOT_DIR` env var.                                                                                                                                       |
 | `on_failed`               | `true`                                                                 | Capture screenshot on failed test.                                                                                                                                                                                                                                                              |
 | `on_every_step`           | `false`                                                                | Automatically capture screenshots after every step. Can be enabled globally via config or per-scenario using the `@screenshots` tag. Only captures on passed steps to avoid duplicates with `on_failed`.                                                                                        |
-| `animation.enabled`       | `false`                                                                | Build an animated GIF per scenario from the per-step screenshots, automatically enabling per-step capture. Can be enabled per-scenario with the `@screenshots:animated` tag and disabled per-scenario with the `@screenshots:animated:skip` tag (both read at scenario or feature level, and both taking precedence over this setting). Requires the `gd` PHP extension. |
+| `animation.enabled`       | `false`                                                                | Build an animated GIF per scenario from the per-step screenshots, automatically enabling per-step capture. Can be enabled per-scenario with the `@screenshots:animated` tag and disabled per-scenario with the `@screenshots:animated:skip` tag (both read at scenario or feature level, and both taking precedence over this setting). Disable for the whole run with the `BEHAT_SCREENSHOT_ANIMATION_SKIP` env var, which overrides both the tags and this setting. Requires the `gd` PHP extension. |
 | `animation.frame_delay`   | `500`                                                                  | Delay between animated GIF frames, in milliseconds.                                                                                                                                                                                                                                             |
 | `animation.max_width`     | `0`                                                                    | Maximum animated GIF frame width, in pixels. Wider frames are cropped to it, keeping the left-hand side. `0` leaves the width unbounded.                                                                                                                                                        |
 | `animation.max_height`    | `0`                                                                    | Maximum animated GIF frame height, in pixels. Taller frames are cropped to it, keeping the top of the page at full resolution and full width. `0` leaves the height unbounded. Useful with `always_fullscreen`, where frame height follows the page height.                                      |

--- a/README.md
+++ b/README.md
@@ -180,6 +180,31 @@ The `@screenshots:animated` tag is read at both the scenario and feature level. 
 
 Each frame keeps the size it was captured at. Frames smaller than the tallest or widest frame of the scenario are shown at the top-left of the animation against a white background, rather than being scaled up or stretched.
 
+#### Skipping animation for a scenario
+
+Animation captures a screenshot after every passed step, so its cost grows with the number of steps in a scenario. To keep animation on across the suite while excluding individual scenarios, use the `@screenshots:animated:skip` tag:
+
+```gherkin
+@javascript @screenshots:animated:skip
+Scenario: Long workflow that should not be recorded
+  Given I am on "http://example.com"
+  # No animated GIF is written, and no per-step screenshots are captured for it.
+```
+
+Tags are resolved from the most specific scope down, so a scenario tag decides on its own, a feature tag applies only when the scenario carries neither tag, and `animation.enabled` applies only when neither scope is tagged:
+
+| Scenario tag                   | Feature tag                    | `animation.enabled` | Animated |
+|--------------------------------|--------------------------------|---------------------|----------|
+| `@screenshots:animated:skip`   | -                              | `true`              | No       |
+| `@screenshots:animated`        | `@screenshots:animated:skip`   | `false`             | Yes      |
+| `@screenshots:animated:skip`   | `@screenshots:animated`        | `true`              | No       |
+| -                              | `@screenshots:animated:skip`   | `true`              | No       |
+| -                              | -                              | `true`              | Yes      |
+
+A scenario or feature carrying both tags at once is not animated - the skip tag wins within a scope.
+
+Skipping animation does not disable the per-step screenshots requested by `on_every_step` or the `@screenshots` tag; those are captured independently. It removes only the captures that animation itself requires.
+
 #### Limiting frame size
 
 With `always_fullscreen: true` every frame is as tall as the page it captured, so one long page - an admin listing, a search result set - produces very large frames and a correspondingly large GIF. Cap them with `max_width` and `max_height`:
@@ -202,7 +227,7 @@ Frames larger than the cap are cropped to it before being encoded, keeping the t
 | `dir`                     | `%paths.base%/screenshots`                                             | Path to directory to save screenshots. Directory structure will be created if the directory does not exist. Override with `BEHAT_SCREENSHOT_DIR` env var.                                                                                                                                       |
 | `on_failed`               | `true`                                                                 | Capture screenshot on failed test.                                                                                                                                                                                                                                                              |
 | `on_every_step`           | `false`                                                                | Automatically capture screenshots after every step. Can be enabled globally via config or per-scenario using the `@screenshots` tag. Only captures on passed steps to avoid duplicates with `on_failed`.                                                                                        |
-| `animation.enabled`       | `false`                                                                | Build an animated GIF per scenario from the per-step screenshots, automatically enabling per-step capture. Can be enabled per-scenario with the `@screenshots:animated` tag (read at scenario or feature level). Requires the `gd` PHP extension.                                                |
+| `animation.enabled`       | `false`                                                                | Build an animated GIF per scenario from the per-step screenshots, automatically enabling per-step capture. Can be enabled per-scenario with the `@screenshots:animated` tag and disabled per-scenario with the `@screenshots:animated:skip` tag (both read at scenario or feature level, and both taking precedence over this setting). Requires the `gd` PHP extension. |
 | `animation.frame_delay`   | `500`                                                                  | Delay between animated GIF frames, in milliseconds.                                                                                                                                                                                                                                             |
 | `animation.max_width`     | `0`                                                                    | Maximum animated GIF frame width, in pixels. Wider frames are cropped to it, keeping the left-hand side. `0` leaves the width unbounded.                                                                                                                                                        |
 | `animation.max_height`    | `0`                                                                    | Maximum animated GIF frame height, in pixels. Taller frames are cropped to it, keeping the top of the page at full resolution and full width. `0` leaves the height unbounded. Useful with `always_fullscreen`, where frame height follows the page height.                                      |

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -62,6 +62,11 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
   public const TAG_SCREENSHOTS_ANIMATED_SKIP = 'screenshots:animated:skip';
 
   /**
+   * Environment variable disabling animated GIF assembly for the whole suite.
+   */
+  public const ENV_ANIMATION_SKIP = 'BEHAT_SCREENSHOT_ANIMATION_SKIP';
+
+  /**
    * Extra window height ensuring the whole page is captured, in pixels.
    */
   public const FULLSCREEN_HEIGHT_BUFFER = 200;
@@ -199,11 +204,14 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
   /**
    * Resolve whether the current scenario should produce an animated GIF.
    *
-   * Scopes are consulted from the most specific to the least specific, so a
-   * scenario tag decides on its own and a feature tag only applies when the
-   * scenario carries neither tag. Within a scope the skip tag wins, making a
-   * node tagged with both an opt-in and an opt-out deterministic. The
-   * animation.enabled setting applies only when no scope is tagged.
+   * The environment variable is a suite-wide switch that overrides everything
+   * a feature file or the configuration can say, so a run can be stripped of
+   * animation without editing either. Below it, scopes are consulted from the
+   * most specific to the least specific, so a scenario tag decides on its own
+   * and a feature tag only applies when the scenario carries neither tag.
+   * Within a scope the skip tag wins, making a node tagged with both an opt-in
+   * and an opt-out deterministic. The animation.enabled setting applies only
+   * when no scope is tagged.
    *
    * @param \Behat\Gherkin\Node\TaggedNodeInterface ...$nodes
    *   Tagged nodes in order of decreasing specificity.
@@ -212,6 +220,10 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
    *   TRUE when the scenario should produce an animated GIF.
    */
   protected function resolveIsAnimated(TaggedNodeInterface ...$nodes): bool {
+    if ($this->isAnimationSkippedForSuite()) {
+      return FALSE;
+    }
+
     foreach ($nodes as $node) {
       if ($node->hasTag(self::TAG_SCREENSHOTS_ANIMATED_SKIP)) {
         return FALSE;
@@ -223,6 +235,16 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
     }
 
     return !empty($this->animation['enabled']);
+  }
+
+  /**
+   * Check whether animation is disabled for the whole suite.
+   *
+   * @return bool
+   *   TRUE when the environment variable holds a truthy value.
+   */
+  protected function isAnimationSkippedForSuite(): bool {
+    return (bool) getenv(self::ENV_ANIMATION_SKIP);
   }
 
   /**

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -8,6 +8,7 @@ use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
+use Behat\Gherkin\Node\TaggedNodeInterface;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\RawMinkContext;
@@ -54,6 +55,11 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
    * Tag enabling animated GIF assembly for a scenario or feature.
    */
   public const TAG_SCREENSHOTS_ANIMATED = 'screenshots:animated';
+
+  /**
+   * Tag disabling animated GIF assembly for a scenario or feature.
+   */
+  public const TAG_SCREENSHOTS_ANIMATED_SKIP = 'screenshots:animated:skip';
 
   /**
    * Extra window height ensuring the whole page is captured, in pixels.
@@ -186,8 +192,37 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
     $feature = $scope->getFeature();
 
     $this->scenarioHasScreenshotsTag = $scenario->hasTag(self::TAG_SCREENSHOTS) || $feature->hasTag(self::TAG_SCREENSHOTS);
-    $this->scenarioIsAnimated = !empty($this->animation['enabled']) || $scenario->hasTag(self::TAG_SCREENSHOTS_ANIMATED) || $feature->hasTag(self::TAG_SCREENSHOTS_ANIMATED);
+    $this->scenarioIsAnimated = $this->resolveIsAnimated($scenario, $feature);
     $this->animationEncoder = NULL;
+  }
+
+  /**
+   * Resolve whether the current scenario should produce an animated GIF.
+   *
+   * Scopes are consulted from the most specific to the least specific, so a
+   * scenario tag decides on its own and a feature tag only applies when the
+   * scenario carries neither tag. Within a scope the skip tag wins, making a
+   * node tagged with both an opt-in and an opt-out deterministic. The
+   * animation.enabled setting applies only when no scope is tagged.
+   *
+   * @param \Behat\Gherkin\Node\TaggedNodeInterface ...$nodes
+   *   Tagged nodes in order of decreasing specificity.
+   *
+   * @return bool
+   *   TRUE when the scenario should produce an animated GIF.
+   */
+  protected function resolveIsAnimated(TaggedNodeInterface ...$nodes): bool {
+    foreach ($nodes as $node) {
+      if ($node->hasTag(self::TAG_SCREENSHOTS_ANIMATED_SKIP)) {
+        return FALSE;
+      }
+
+      if ($node->hasTag(self::TAG_SCREENSHOTS_ANIMATED)) {
+        return TRUE;
+      }
+    }
+
+    return !empty($this->animation['enabled']);
   }
 
   /**

--- a/tests/behat/features/screenshot_behatcli.feature
+++ b/tests/behat/features/screenshot_behatcli.feature
@@ -402,6 +402,26 @@ Feature: Screenshot context
     And behat cli file wildcard "screenshots/*.gif" should exist
 
   @selenium
+  Scenario: Test Screenshot context skips an animated GIF when tagged to skip while animation is enabled globally
+    Given screenshot fixture
+    And screenshot context behat configuration with value:
+      """
+      DrevOps\BehatScreenshotExtension:
+            dir: "%paths.base%/screenshots"
+            purge: true
+            animation:
+              enabled: true
+      """
+    And scenario steps tagged with "@phpserver @javascript @screenshots:animated:skip":
+      """
+      When I am on the phpserver test page
+      And I save screenshot
+      """
+    When I run "behat --no-colors --strict"
+    Then it should pass
+    And behat cli file wildcard "screenshots/*.gif" should not exist
+
+  @selenium
   Scenario: Test Screenshot context with JS full-screen short screenshot
     Given short screenshot fixture
     And screenshot context behat configuration with value:

--- a/tests/behat/features/screenshot_behatcli.feature
+++ b/tests/behat/features/screenshot_behatcli.feature
@@ -422,6 +422,26 @@ Feature: Screenshot context
     And behat cli file wildcard "screenshots/*.gif" should not exist
 
   @selenium
+  Scenario: Test Screenshot context skips an animated GIF for the whole suite when the environment variable is set
+    Given screenshot fixture
+    And screenshot context behat configuration with value:
+      """
+      DrevOps\BehatScreenshotExtension:
+            dir: "%paths.base%/screenshots"
+            purge: true
+      """
+    And scenario steps tagged with "@phpserver @javascript @screenshots:animated":
+      """
+      When I am on the phpserver test page
+      And I save screenshot
+      """
+    And "BEHAT_SCREENSHOT_ANIMATION_SKIP" environment variable is set to "1"
+    When I run "behat --no-colors --strict"
+    Then it should pass
+    And behat cli file wildcard "screenshots/*.png" should exist
+    And behat cli file wildcard "screenshots/*.gif" should not exist
+
+  @selenium
   Scenario: Test Screenshot context with JS full-screen short screenshot
     Given short screenshot fixture
     And screenshot context behat configuration with value:

--- a/tests/phpunit/Unit/ScreenshotContextAnimationTest.php
+++ b/tests/phpunit/Unit/ScreenshotContextAnimationTest.php
@@ -53,6 +53,14 @@ class ScreenshotContextAnimationTest extends TestCase {
       'feature animated tag' => [[], ['screenshots:animated'], [], FALSE, TRUE],
       'animation enabled via config' => [[], [], ['enabled' => TRUE], FALSE, TRUE],
       'animation disabled via config' => [[], [], ['enabled' => FALSE], FALSE, FALSE],
+      'feature animated tag over disabled config' => [[], ['screenshots:animated'], ['enabled' => FALSE], FALSE, TRUE],
+      'scenario skip tag over enabled config' => [['screenshots:animated:skip'], [], ['enabled' => TRUE], FALSE, FALSE],
+      'feature skip tag over enabled config' => [[], ['screenshots:animated:skip'], ['enabled' => TRUE], FALSE, FALSE],
+      'scenario skip tag with disabled config' => [['screenshots:animated:skip'], [], ['enabled' => FALSE], FALSE, FALSE],
+      'scenario skip tag over scenario animated tag' => [['screenshots:animated', 'screenshots:animated:skip'], [], [], FALSE, FALSE],
+      'feature skip tag over feature animated tag' => [[], ['screenshots:animated', 'screenshots:animated:skip'], [], FALSE, FALSE],
+      'scenario animated tag over feature skip tag' => [['screenshots:animated'], ['screenshots:animated:skip'], ['enabled' => FALSE], FALSE, TRUE],
+      'scenario skip tag over feature animated tag' => [['screenshots:animated:skip'], ['screenshots:animated'], ['enabled' => TRUE], FALSE, FALSE],
     ];
   }
 

--- a/tests/phpunit/Unit/ScreenshotContextAnimationTest.php
+++ b/tests/phpunit/Unit/ScreenshotContextAnimationTest.php
@@ -64,6 +64,54 @@ class ScreenshotContextAnimationTest extends TestCase {
     ];
   }
 
+  #[DataProvider('dataProviderBeforeScenarioCheckScreenshotsTagHonoursSuiteEnvironmentVariable')]
+  public function testBeforeScenarioCheckScreenshotsTagHonoursSuiteEnvironmentVariable(?string $env_value, array $scenario_tags, array $feature_tags, array $animation, bool $expected_animated): void {
+    $original_value = getenv(ScreenshotContext::ENV_ANIMATION_SKIP);
+
+    try {
+      if ($env_value === NULL) {
+        putenv(ScreenshotContext::ENV_ANIMATION_SKIP);
+      }
+      else {
+        putenv(ScreenshotContext::ENV_ANIMATION_SKIP . '=' . $env_value);
+      }
+
+      $env = $this->createMock(Environment::class);
+      $feature_node = $this->createMock(FeatureNode::class);
+      $feature_node->method('hasTag')->willReturnCallback(static fn(string $tag): bool => in_array($tag, $feature_tags, TRUE));
+      $scenario = $this->createMock(ScenarioInterface::class);
+      $scenario->method('hasTag')->willReturnCallback(static fn(string $tag): bool => in_array($tag, $scenario_tags, TRUE));
+
+      $screenshot_context = new ScreenshotContext();
+      $screenshot_context->setScreenshotParameters('test-dir', TRUE, 'failed_', FALSE, FALSE, '{ext}', '{ext}', [], $animation);
+
+      $screenshot_context->beforeScenarioCheckScreenshotsTag(new BeforeScenarioScope($env, $feature_node, $scenario));
+
+      $this->assertSame($expected_animated, self::getProtectedValue($screenshot_context, 'scenarioIsAnimated'));
+    }
+    finally {
+      if ($original_value !== FALSE) {
+        putenv(ScreenshotContext::ENV_ANIMATION_SKIP . '=' . $original_value);
+      }
+      else {
+        putenv(ScreenshotContext::ENV_ANIMATION_SKIP);
+      }
+    }
+  }
+
+  public static function dataProviderBeforeScenarioCheckScreenshotsTagHonoursSuiteEnvironmentVariable(): array {
+    return [
+      'variable unset with config enabled' => [NULL, [], [], ['enabled' => TRUE], TRUE],
+      'variable set with config enabled' => ['1', [], [], ['enabled' => TRUE], FALSE],
+      'variable set with config disabled' => ['1', [], [], ['enabled' => FALSE], FALSE],
+      'variable set over scenario animated tag' => ['1', ['screenshots:animated'], [], [], FALSE],
+      'variable set over feature animated tag' => ['1', [], ['screenshots:animated'], [], FALSE],
+      'variable empty with config enabled' => ['', [], [], ['enabled' => TRUE], TRUE],
+      'variable zero with config enabled' => ['0', [], [], ['enabled' => TRUE], TRUE],
+      'variable zero with scenario animated tag' => ['0', ['screenshots:animated'], [], [], TRUE],
+    ];
+  }
+
   public function testCaptureScreenshotAfterStepCollectsAnimationFrame(): void {
     $encoder = $this->createMock(AnimatedGif::class);
     $encoder->expects($this->once())->method('addFrame')->with('png-bytes');


### PR DESCRIPTION
Closes #264

## Summary

Animation was opt-in only: once `animation.enabled` was true, the decision in `ScreenshotContext::beforeScenarioCheckScreenshotsTag()` was a flat OR, so no tag could turn animation back off for an individual scenario. A suite that wanted "animation everywhere except these few" had no way to express the exception, and animation costs roughly double the wall time on a long scenario because it forces a full-page capture after every passed step.

This adds two ways to turn animation off. The `@screenshots:animated:skip` tag excludes a single scenario or feature, and the `BEHAT_SCREENSHOT_ANIMATION_SKIP` environment variable disables animation for an entire run without touching feature files or configuration. The flat OR is replaced by a resolution that walks scopes from most to least specific, which also gives the granularity the issue asked about: a feature-level opt-out can be overridden by a scenario-level opt-in.

## Changes

### Resolution logic

- Added `resolveIsAnimated()` to `ScreenshotContext`, replacing the inline boolean expression. It short-circuits on the environment variable, then consults each tagged node in order of decreasing specificity (scenario, then feature), then falls back to `animation.enabled`. Both `ScenarioInterface` and `FeatureNode` implement `TaggedNodeInterface`, so a single variadic parameter covers both scopes and the precedence is expressed by argument order rather than by operator order.
- Within a scope the skip tag is checked before the opt-in tag, so a node carrying both resolves deterministically to not-animated rather than being left undefined.
- Added `isAnimationSkippedForSuite()`, which reads the environment variable with the same truthiness convention as the existing `BEHAT_SCREENSHOT_PURGE` handling.
- Added the `TAG_SCREENSHOTS_ANIMATED_SKIP` and `ENV_ANIMATION_SKIP` public constants alongside the existing `TAG_SCREENSHOTS` and `TAG_SCREENSHOTS_ANIMATED`.

Turning animation off for a scenario also stops the per-step captures that animation implies, since `captureScreenshotAfterStep()` already keys off `scenarioIsAnimated` - that is where the measured time goes. Per-step captures requested independently by `on_every_step` or the `@screenshots` tag are unaffected.

### Tests

- Extended the existing `beforeScenarioCheckScreenshotsTag` data provider with 8 rows covering the skip tag against enabled and disabled config, the same-scope conflict at both scenario and feature level, and scenario-over-feature precedence in both directions. Added a regression row asserting a feature-level opt-in still beats disabled config.
- Added a second data-provider test covering the environment variable: set against enabled config, set against a scenario tag, set against a feature tag, and the falsy values (unset, empty, `0`) that must leave animation on.
- Added two Behat CLI scenarios: one asserting no GIF is written when the skip tag is present while `animation.enabled: true`, and one asserting no GIF is written when the environment variable is set while the scenario carries `@screenshots:animated`, with the per-step PNGs still produced.

### Documentation

- Added a "Skipping animation for a scenario" section to the README covering the tag, the environment variable, and a precedence table over all four inputs.
- Updated the `animation.enabled` row in the options table.

## Before / After

Before, the decision was a flat OR, so a truthy `config.enabled` made the result unconditionally true:

    scenario.hasTag(animated) OR feature.hasTag(animated) OR config.enabled
                                    │
                                    ▼
                    ┌────────────────────────────────┐
                    │  animated = TRUE / FALSE       │
                    │  (no opt-out at any level)     │
                    └────────────────────────────────┘

After, each input is consulted in precedence order and the first match decides:

    ┌─────────────────────────────┐
    │ BEHAT_SCREENSHOT_           │──set───▶ NOT animated  (whole suite)
    │ ANIMATION_SKIP set?         │
    └──────────────┬──────────────┘
                   │ no
                   ▼
    ┌─────────────────────────────┐
    │ scenario has skip tag?      │──yes───▶ NOT animated
    └──────────────┬──────────────┘
                   │ no
                   ▼
    ┌─────────────────────────────┐
    │ scenario has animated tag?  │──yes───▶ animated
    └──────────────┬──────────────┘
                   │ no
                   ▼
    ┌─────────────────────────────┐
    │ feature has skip tag?       │──yes───▶ NOT animated
    └──────────────┬──────────────┘
                   │ no
                   ▼
    ┌─────────────────────────────┐
    │ feature has animated tag?   │──yes───▶ animated
    └──────────────┬──────────────┘
                   │ no
                   ▼
    ┌─────────────────────────────┐
    │ animation.enabled config    │────────▶ animated / NOT animated
    └─────────────────────────────┘
