### PR TITLE
Aligned the documentation with the code, tidied source comments, and added a security policy.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,13 @@ These are the standard operations that should be performed when working with thi
 
 ### Code Quality Checks
 ```
-composer lint       # Run all linting tools
-composer lint-fix   # Automatically fix linting issues 
-composer test       # Run PHPUnit tests without coverage
+composer lint           # Run all linting tools
+composer lint-fix       # Automatically fix linting issues
+composer test           # Run PHPUnit tests without coverage
+composer test-coverage  # Run PHPUnit tests with coverage
 ```
+
+See `CONTRIBUTING.md` for the BDD test suite and the animation profiler.
 
 ### Coding Standards
 - Follow Drupal coding standards
@@ -20,23 +23,16 @@ composer test       # Run PHPUnit tests without coverage
 
 ### PHPUnit Configuration
 - Uses PHPUnit 11.5 with configuration in phpunit.xml
-- Coverage reports are generated in .logs/coverage directory
-
-## Recent Improvements
-- Fullscreen screenshots use the resize algorithm (temporarily resizes browser window to capture full page)
-- Updated autoloader from PSR-0 to PSR-4
-- Made constants public as per PHP 8.2+ standards
-- Improved error messages for file operations
-- Optimized token replacement logic
-- Updated PHPUnit configuration to remove deprecated attributes
-- Ensured all variables follow Drupal's snake_case naming convention
+- Coverage reports are generated in .logs/coverage/phpunit
 
 ## Code Structure
 The Behat Screenshot extension provides functionality to capture screenshots during Behat test runs. Its main components are:
 
-1. **BehatScreenshotExtension**: Handles configuration and service container integration
-2. **ScreenshotContext**: Provides Behat steps and screenshot capabilities, including fullscreen screenshot functionality
-3. **Tokenizer**: Processes dynamic filename generation with tokens
+1. **BehatScreenshotExtension**: Defines the configuration schema and registers the initializer with the service container
+2. **ScreenshotContextInitializer**: Passes the resolved configuration to every screenshot-aware context and purges the screenshot directory when enabled
+3. **ScreenshotContext**: Provides the Behat steps and hooks; fullscreen capture temporarily resizes the browser window to the full page height
+4. **AnimatedGif**: Assembles a scenario's captured frames into a single animated GIF
+5. **Tokenizer**: Expands the tokens used in filename patterns
 
 ## Best Practices for Contributing
 1. Always run tests before and after changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ docker run -d -p 4444:4444 -p 9222:9222 selenium/standalone-chromium
 brew install --cask chromium
 # Launch Chromium with remote debugging.
 "$(brew --prefix)/bin/chromium" \
-  --remote-debugging-address=0.0.0.0 \
+  --remote-debugging-address=127.0.0.1 \
   --remote-debugging-port=9222
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ composer install
 ## Linting
 
 ```shell
-composer lint      # Check coding standards, run static analysis and lint feature files.
+composer lint      # Check standards, run static analysis, lint feature files.
 composer lint-fix  # Apply the fixes Rector and PHPCBF can make automatically.
 ```
 
@@ -33,7 +33,9 @@ docker run -d -p 4444:4444 -p 9222:9222 selenium/standalone-chromium
 # Install Chromium with brew.
 brew install --cask chromium
 # Launch Chromium with remote debugging.
-"$(brew --prefix)/bin/chromium" --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
+"$(brew --prefix)/bin/chromium" \
+  --remote-debugging-address=0.0.0.0 \
+  --remote-debugging-port=9222
 ```
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ default:
       purge: false
       always_fullscreen: false
       failed_prefix: 'failed_'
-      filename_pattern: '{datetime:u}.{feature_file}.feature_{step_line}.{ext}'
-      filename_pattern_failed: '{datetime:u}.{failed_prefix}{feature_file}.feature_{step_line}.{ext}'
+      filename_pattern: '{datetime:U}.{feature_file}.feature_{step_line}.{ext}'
+      filename_pattern_failed: '{datetime:U}.{failed_prefix}{feature_file}.feature_{step_line}.{ext}'
 ```
 
 In your feature:
@@ -242,30 +242,32 @@ Frames larger than the cap are cropped to it before being encoded, keeping the t
 | `animation.max_height`    | `0`                                                                    | Maximum animated GIF frame height, in pixels. Taller frames are cropped to it, keeping the top of the page at full resolution and full width. `0` leaves the height unbounded. Useful with `always_fullscreen`, where frame height follows the page height.                                      |
 | `purge`                   | `false`                                                                | Remove all files from the screenshots directory on each test run. Useful during debugging of tests.                                                                                                                                                                                             |
 | `always_fullscreen`       | `false`                                                                | Always use fullscreen screenshot capture for all screenshot steps, including regular screenshot steps. When enabled, all `I save screenshot` steps will behave like `I save fullscreen screenshot`.                                                                                             |
-| `info_types`              | `url`, `feature`, `step`, `datetime`                                   | Show additional information on screenshots. Comma-separated list of `url`, `feature`, `step`, `datetime`, or remove to disable. Ordered as listed.                                                                                                                                              |
+| `info_types`              | none                                                                   | List of additional information types to show on screenshots: `url`, `feature`, `step`, `datetime`. Rendered in the order listed. No information is added unless this option is set.                                                                                                            |
 | `failed_prefix`           | `failed_`                                                              | Prefix failed screenshots with `failed_` string. Useful to distinguish failed and intended screenshots.                                                                                                                                                                                         |
-| `filename_pattern`        | `{datetime:u}.{feature_file}.feature_{step_line}.{ext}`                | File name pattern for successful assertions.                                                                                                                                                                                                                                                    |
-| `filename_pattern_failed` | `{datetime:u}.{failed_prefix}{feature_file}.feature_{step_line}.{ext}` | File name pattern for failed assertions.                                                                                                                                                                                                                                                        |
+| `filename_pattern`        | `{datetime:U}.{feature_file}.feature_{step_line}.{ext}`                | File name pattern for successful assertions.                                                                                                                                                                                                                                                    |
+| `filename_pattern_failed` | `{datetime:U}.{failed_prefix}{feature_file}.feature_{step_line}.{ext}` | File name pattern for failed assertions.                                                                                                                                                                                                                                                        |
 
 ### File name tokens
 
-| Token              | Substituted with                                                                | Example value(s)                                                  |
-|--------------------|---------------------------------------------------------------------------------|-------------------------------------------------------------------|
-| `{ext}`            | The extension of the file captured                                              | `html` or `png`                                                   |
-| `{failed_prefix}`  | The value of failed_prefix from configuration                                   | `failed_`, `error_` (do include the `_` suffix, if required)      |
-| `{url}`            | Full URL                                                                        | `http_example_com_mypath_subpath_query_myquery_1_plus_2_fragment` |
-| `{url_origin}`     | Scheme with domain                                                              | `http_example_com`                                                |
-| `{url_relative}`   | Path + query + fragment                                                         | `mypath_subpath_query_myquery_1_plus_2_fragment`                  |
-| `{url_domain}`     | Domain                                                                          | `example_com`                                                     |
-| `{url_path}`       | Path                                                                            | `mypath_subpath`                                                  |
-| `{url_query}`      | Query                                                                           | `myquery_1_plus_2`                                                |
-| `{url_fragment}`   | Fragment                                                                        | `somefragment`                                                    |
-| `{feature_file}`   | The filename of the `.feature` file currently being executed, without extension | `my_example.feature` -> `my_example`                              |
-| `{step_line}`      | Step line number                                                                | `1`, `10`, `100`                                                  |
-| `{step_line:%03d}` | Step line number with leading zeros. Modifiers are from `sprintf()`.            | `001`, `010`, `100`                                               |
-| `{step_name}`      | Step name without `Given/When/Then` and lower-cased.                            | `i_am_on_the_test_page`                                           |
-| `{datetime}`       | Current date and time. defaults to `Ymd_His` format.                            | `20010310_171618`                                                 |
-| `{datetime:U}`     | Current date and time as microtime. Modifiers are from `date()`.                | `1697490961192498`                                                |
+Every character other than a letter, digit, underscore or hyphen is replaced with an underscore, and consecutive replacements collapse into one. The URL examples below are for a page at `http://example.com/mypath/subpath?myquery=1#somefragment`.
+
+| Token              | Substituted with                                                                | Example value(s)                                             |
+|--------------------|---------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `{ext}`            | The extension of the file captured                                              | `html` or `png`                                              |
+| `{failed_prefix}`  | The value of failed_prefix from configuration                                   | `failed_`, `error_` (do include the `_` suffix, if required) |
+| `{url}`            | Full URL                                                                        | `http_example_com_mypath_subpath_myquery_1_somefragment`     |
+| `{url_origin}`     | Scheme with domain                                                              | `http_example_com`                                           |
+| `{url_relative}`   | Path + query + fragment                                                         | `mypath_subpath_myquery_1_somefragment`                      |
+| `{url_domain}`     | Domain                                                                          | `example_com`                                                |
+| `{url_path}`       | Path                                                                            | `mypath_subpath`                                             |
+| `{url_query}`      | Query                                                                           | `myquery_1`                                                  |
+| `{url_fragment}`   | Fragment                                                                        | `somefragment`                                               |
+| `{feature_file}`   | The filename of the `.feature` file currently being executed, without extension | `my_example.feature` -> `my_example`                         |
+| `{step_line}`      | Step line number                                                                | `1`, `10`, `100`                                             |
+| `{step_line:%03d}` | Step line number with leading zeros. Modifiers are from `sprintf()`.            | `001`, `010`, `100`                                          |
+| `{step_name}`      | Step name without `Given/When/Then`, with spaces replaced by underscores        | `I_am_on_the_test_page`                                      |
+| `{datetime}`       | Current date and time. Defaults to the `Ymd_His` format.                        | `20010310_171618`                                            |
+| `{datetime:U}`     | Current date and time as a Unix timestamp. Modifiers are from `date()`.         | `1697490961`                                                 |
 
 ## Auto-purge
 
@@ -292,11 +294,20 @@ BEHAT_SCREENSHOT_PURGE=1 vendor/bin/behat
 
 ## Additional information on screenshots
 
-You can enable additional information on screenshots by setting `info_types` in
-the configuration. The order of the types will be the order of the information
-displayed on the screenshot.
+No additional information is added to screenshots unless `info_types` is set in the configuration. The order of the types is the order of the information displayed on the screenshot.
 
-By default, the information displayed is the URL, feature file name, step line:
+```yaml
+default:
+  extensions:
+    DrevOps\BehatScreenshotExtension:
+      info_types:
+        - url
+        - feature
+        - step
+        - datetime
+```
+
+With all four types enabled, the information is prepended to the captured HTML:
 
 ```html
 Current URL: http://example.com<br/>
@@ -310,19 +321,18 @@ Datetime: 2025-01-19 00:01:10
 </html>
 ```
 
-More information can be added by setting the `info_types` configuration option
-and using `addInfo()` method in your context class.
+Custom entries can be added from your own context class with `appendInfo()`. They are rendered alongside the entries produced by `info_types`.
 
 ```php
 /**
  * @BeforeScenario
  */
-public function beforeScenarioUpdateBaseUrl(BeforeScenarioScope $scope): void {
+public function beforeScenarioAddInfo(BeforeScenarioScope $scope): void {
   $environment = $scope->getEnvironment();
   if ($environment instanceof InitializedContextEnvironment) {
     foreach ($environment->getContexts() as $context) {
       if ($context instanceof ScreenshotContext) {
-        $context->addInfo('Custom info', 'My custom info');
+        $context->appendInfo('Custom info', 'My custom info');
       }
     }
   }
@@ -334,4 +344,4 @@ public function beforeScenarioUpdateBaseUrl(BeforeScenarioScope $scope): void {
 See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, linting, unit and BDD tests, and the animated GIF assembly profiler.
 
 ---
-_Repository created using https://getscaffold.dev/ project scaffold template_
+_This repository was created using the [Scaffold](https://getscaffold.dev/) project template_

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ BEHAT_SCREENSHOT_PURGE=1 vendor/bin/behat
 
 ## Additional information on screenshots
 
-No additional information is added to screenshots unless `info_types` is set in the configuration. The order of the types is the order of the information displayed on the screenshot.
+The `info_types` option controls which built-in information is added to screenshots, and nothing is added unless it is set. The order of the types is the order of the information displayed on the screenshot.
 
 ```yaml
 default:
@@ -321,7 +321,7 @@ Datetime: 2025-01-19 00:01:10
 </html>
 ```
 
-Custom entries can be added from your own context class with `appendInfo()`. They are rendered alongside the entries produced by `info_types`.
+Custom entries can be added from your own context class with `appendInfo()`. They are rendered alongside the entries produced by `info_types`, and are rendered whether or not `info_types` is set.
 
 ```php
 /**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are released for the latest `2.x` version. Earlier release lines no longer receive updates.
+
+| Version | Supported |
+|---------|-----------|
+| 2.x     | Yes       |
+| 1.x     | No        |
+| 0.x     | No        |
+
+## Reporting a vulnerability
+
+Report vulnerabilities privately through [GitHub Security Advisories](https://github.com/drevops/behat-screenshot/security/advisories/new). Do not open a public issue for a security report.
+
+Include the affected version, the steps to reproduce, and the impact you expect. A proof of concept helps but is not required.
+
+You can expect an initial response within 7 days. Once a report is confirmed, a fix and an advisory are published together, crediting you unless you ask otherwise.
+
+## Scope
+
+This package is a development dependency that captures screenshots during Behat test runs. It reads the page content exposed by the Mink driver, writes files into a configured directory, and deletes files from that directory when `purge` is enabled. It executes no external commands.
+
+In scope: token expansion producing unsafe file paths, writes or deletions escaping the configured directory, and captured content reaching unintended locations.

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -22,5 +22,5 @@ default:
         - step
         - datetime
       failed_prefix: failed_
-      filename_pattern: '{datetime:u}.{feature_file}.feature_{step_line}.{ext}'
-      filename_pattern_failed: '{datetime:u}.{failed_prefix}{feature_file}.feature_{step_line}.{ext}'
+      filename_pattern: '{datetime:U}.{feature_file}.feature_{step_line}.{ext}'
+      filename_pattern_failed: '{datetime:U}.{failed_prefix}{feature_file}.feature_{step_line}.{ext}'

--- a/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/Initializer/ScreenshotContextInitializer.php
@@ -11,7 +11,9 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
 /**
- * Class ScreenshotContextInitializer.
+ * Passes the extension configuration to every screenshot-aware context.
+ *
+ * Purges the screenshot directory once per run when purging is enabled.
  */
 class ScreenshotContextInitializer implements ContextInitializer {
 

--- a/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
+++ b/src/DrevOps/BehatScreenshotExtension/Context/ScreenshotContext.php
@@ -17,7 +17,10 @@ use DrevOps\BehatScreenshotExtension\Tokenizer;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * Class ScreenshotContext.
+ * Captures HTML and image screenshots during a Behat run.
+ *
+ * Provides the screenshot steps, the hooks that capture on failure and after
+ * every step, and the per-scenario animated GIF assembly.
  */
 class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContextInterface {
 
@@ -469,7 +472,6 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
     }
     // @codeCoverageIgnoreStart
     catch (UnsupportedDriverActionException) {
-      // Drivers without screenshot support do not have them created.
       return;
     }
     // @codeCoverageIgnoreEnd
@@ -505,7 +507,6 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
    */
   protected function getScreenshotFullscreenWithResize(): string {
     $session = $this->getSession();
-    $session->getDriver();
 
     $original_width = self::DEFAULT_WINDOW_WIDTH;
     $original_height = self::DEFAULT_WINDOW_HEIGHT;
@@ -554,9 +555,7 @@ class ScreenshotContext extends RawMinkContext implements ScreenshotAwareContext
     }
 
     $fullscreen_width = $original_width ?: self::DEFAULT_WINDOW_WIDTH;
-    $fullscreen_height = $scroll_height;
-
-    $fullscreen_height += self::FULLSCREEN_HEIGHT_BUFFER;
+    $fullscreen_height = $scroll_height + self::FULLSCREEN_HEIGHT_BUFFER;
 
     $session->resizeWindow($fullscreen_width, $fullscreen_height, self::WINDOW_NAME_CURRENT);
 

--- a/tests/behat/features/screenshot_behatcli.feature
+++ b/tests/behat/features/screenshot_behatcli.feature
@@ -465,7 +465,7 @@ Feature: Screenshot context
   # Test for a headless browser using behat-chrome/behat-chrome-extension driver.
   # @see https://gitlab.com/behat-chrome/behat-chrome-extension
   # Install Chromium with brew: `brew install --cask chromium`
-  # Launch chrome: "$(brew --prefix)/bin/chromium" --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222
+  # Launch chrome: "$(brew --prefix)/bin/chromium" --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222
   # Note: this test does not use the Docker container. See CONTRIBUTING.md for more information.
   @headless
   Scenario: Test Screenshot context using behat-chrome/behat-chrome-extension


### PR DESCRIPTION
## Summary

This is a documentation-drift and polish pass with no behavioral changes: it corrects README.md, behat.yml.dist and CLAUDE.md claims that had drifted out of sync with the actual code, fixes a code sample that called a method that does not exist, tidies a few source comments and a split assignment, binds the documented Chromium debugging endpoint to loopback, and adds a SECURITY.md policy.

## Changes

### Documentation corrected to match the code

- `README.md`: fixed the `filename_pattern` / `filename_pattern_failed` defaults from `{datetime:u}` to `{datetime:U}` in both the config example and the options table. Lowercase `u` is microseconds, which `date()` renders as `000000` for an integer timestamp, so every generated filename would have collided.
- `README.md`: corrected the `info_types` default from `url, feature, step, datetime` to empty, and reworded the "Additional information on screenshots" section so the claim is scoped to the built-in information that `info_types` controls, adding an explicit YAML example
- `README.md`: corrected the `{datetime:U}` token description from "microtime" to "Unix timestamp" and updated its example value
- `README.md`: corrected the `{step_name}` token description - it preserves case and replaces spaces with underscores, it does not lower-case
- `README.md`: rewrote the URL token examples to show the sanitizer's real output (underscored, with no literal `query`/`fragment`/`plus` words) and added a sentence explaining the sanitization rule
- `README.md`: fixed the custom-info example, which called a non-existent `addInfo()` method, to call the real `appendInfo()` method, and documented that `appendInfo()` entries render whether or not `info_types` is set
- `behat.yml.dist`: applied the same `{datetime:u}` to `{datetime:U}` fix as README.md

### Security

- `CONTRIBUTING.md` and `tests/behat/features/screenshot_behatcli.feature`: bound the documented Chromium DevTools endpoint to `127.0.0.1` instead of `0.0.0.0`. The headless scenario connects to `api_url: "http://127.0.0.1:9222"`, so the wildcard bind exposed unauthenticated browser control to the local network for no functional gain. The CI workflow keeps its `0.0.0.0` bind, since it runs on an ephemeral isolated runner.

### CLAUDE.md and CONTRIBUTING.md polish

- Removed the "Recent Improvements" changelog section from `CLAUDE.md`
- Corrected the component list in `CLAUDE.md` to include `ScreenshotContextInitializer` and `AnimatedGif`, and to describe each component's actual responsibility
- Added `composer test-coverage` to the documented commands and pointed to `CONTRIBUTING.md` for the BDD suite and the animation profiler
- Corrected the coverage report path from `.logs/coverage` to `.logs/coverage/phpunit`
- Reworded the `CONTRIBUTING.md` lint comment and wrapped the long Chromium remote-debugging command across multiple lines

### Source cleanup

- `ScreenshotContext.php`: removed a discarded no-op `$session->getDriver();` call, folded a split `$fullscreen_height` assignment into a single statement, and deleted a comment that duplicated the explanation already given above the `try` block. The discarded call was a copy-paste remnant from the stitching implementation removed in bf89349, where the result was assigned and used; `Session::getDriver()` is a plain getter, and the driver is started explicitly in `beforeScenarioInit()`.
- `ScreenshotContext.php` and `ScreenshotContextInitializer.php`: replaced the placeholder `Class Xxx.` docblocks with summaries of what each class actually does

### New security policy

- Added `SECURITY.md` describing supported versions, the vulnerability reporting process through GitHub Security Advisories, and the package's file-system scope

## Before / After

```
┌────────────────────────────────┐         ┌────────────────────────────────┐
│         BEFORE (docs)          │         │          AFTER (docs)          │
│    README & behat.yml.dist     │   ──▶   │    README & behat.yml.dist     │
│      documented defaults       │         │       now match the code       │
└────────────────────────────────┘         └────────────────────────────────┘
```

| Item | Documented (before) | Actual behavior (after) |
|---|---|---|
| `filename_pattern` / `filename_pattern_failed` default | `{datetime:u}.{feature_file}...` | `{datetime:U}.{feature_file}...` |
| `info_types` default | `url, feature, step, datetime` | empty - no built-in information until set |
| `appendInfo()` entries | undocumented | rendered whether or not `info_types` is set |
| `{datetime:U}` token | "microtime", e.g. `1697490961192498` | Unix timestamp, e.g. `1697490961` |
| `{step_name}` token | "lower-cased" | case preserved, spaces become underscores |
| `{url_relative}` example | `mypath_subpath_query_myquery_1_plus_2_fragment` | `mypath_subpath_myquery_1_somefragment` |
| Custom info example | `$context->addInfo(...)` (method does not exist) | `$context->appendInfo(...)` |
| Documented Chromium bind | `--remote-debugging-address=0.0.0.0` | `--remote-debugging-address=127.0.0.1` |
