### PR TITLE
Capped 'dvdoug/behat-code-coverage' below 5.4 to keep PHP 8.2 support.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,12 @@
             "enabled": false
         },
         {
+            "description": "5.4.0 requires php ^8.3 and phpunit/php-code-coverage ^12.3, which conflicts with the supported PHP floor and phpunit/phpunit ^11.5",
+            "matchManagers": ["composer"],
+            "matchPackageNames": ["dvdoug/behat-code-coverage"],
+            "allowedVersions": "<5.4"
+        },
+        {
             "matchPackageNames": ["*"],
             "groupName": "all dependencies",
             "groupSlug": "all"


### PR DESCRIPTION
## Summary

Renovate proposed bumping `dvdoug/behat-code-coverage` from `^5.3.7` to `^5.5.0` in PR #265 alongside two unrelated, compatible updates, and all 8 CI jobs failed at the `composer install` step before any test ran. Starting with 5.4.0, the package requires `php ^8.3` and `phpunit/php-code-coverage ^12.3||^13.0||^14.0`, both of which conflict with this project's PHP 8.2 support and its `phpunit/phpunit ^11.5.56` pin on `phpunit/php-code-coverage ^11.0.12`. Because the version jump is a semver MINOR bump, the existing `matchUpdateTypes: ["major"]` guard in `renovate.json` did not block it. This adds a dedicated `packageRule` that caps `dvdoug/behat-code-coverage` below 5.4, so future Renovate runs stop proposing the incompatible version while still proposing the compatible bumps.

## Changes

- Added a `packageRule` to `renovate.json` matching `dvdoug/behat-code-coverage` on the composer manager, setting `allowedVersions: "<5.4"` and documenting the reason in its `description` field.
- Left the existing major-update guard untouched, since it does not apply here: 5.3.7 to 5.5.0 is a MINOR release per semver even though it raises the package's own PHP floor and jumps a major peer-dependency requirement.
- Renovate PR #265 is configured as "Immortal" (recreated automatically if closed unmerged), so closing that PR alone would not have stopped the incompatible bump from returning; the `renovate.json` rule is the durable fix.

## Before / After

```
BEFORE - renovate.json without the cap
────────────────────────────────────────────────────────────────
Renovate PR #265 "Update all dependencies" (branch deps/all)
  ├─ dantleech/gherkin-lint     ^0.2.3 -> ^0.2.4    OK
  ├─ symfony/process            ^7.0   -> ^7.4.13   OK
  └─ dvdoug/behat-code-coverage ^5.3.7 -> ^5.5.0    INCOMPATIBLE
                    │
                    ▼
            composer install
                    │
        ┌───────────┴────────────┐
        ▼                        ▼
 PHP 8.2 jobs (2)        PHP 8.3 / 8.4 / 8.5 jobs (6)
 needs php ^8.3          php-code-coverage ^12.3 clashes
        ✗ FAIL           with phpunit's pinned ^11.0.12
                                  ✗ FAIL

        Result: 8 / 8 CI jobs fail at composer install, no tests run


AFTER - renovate.json with the cap
────────────────────────────────────────────────────────────────
renovate.json packageRule: allowedVersions "<5.4" for dvdoug/behat-code-coverage

Renovate PR #265 regenerated
  ├─ dantleech/gherkin-lint     ^0.2.3 -> ^0.2.4    OK
  ├─ symfony/process            ^7.0   -> ^7.4.13   OK
  └─ dvdoug/behat-code-coverage held at ^5.3.7      excluded from the bump
                    │
                    ▼
            composer install
                    │
                    ▼
        Result: 8 / 8 CI jobs install cleanly and run tests
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted automatic updates for `dvdoug/behat-code-coverage` to compatible versions below 5.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->